### PR TITLE
Fixed the scroll issue.

### DIFF
--- a/lib/programs screen/girl_script.dart
+++ b/lib/programs screen/girl_script.dart
@@ -182,7 +182,6 @@ class _GSSOCScreenState extends State<GSSOCScreen> {
                       height: height * 0.2,
                       width: width,
                       child: GridView(
-                        physics: const NeverScrollableScrollPhysics(),
                         gridDelegate:
                             const SliverGridDelegateWithFixedCrossAxisCount(
                           crossAxisCount: 2,

--- a/lib/programs screen/google_season_of_docs_screen.dart
+++ b/lib/programs screen/google_season_of_docs_screen.dart
@@ -225,7 +225,6 @@ class _GoogleSeasonOfDocsScreenState extends State<GoogleSeasonOfDocsScreen> {
                       height: height * 0.25,
                       width: width,
                       child: GridView(
-                        physics: const NeverScrollableScrollPhysics(),
                         gridDelegate:
                             const SliverGridDelegateWithFixedCrossAxisCount(
                           crossAxisCount: 2,


### PR DESCRIPTION
Fixed the scroll issue as mentioned in Issue #85 , by removing "physics: const NeverScrollableScrollPhysics()," from both of the pages.