### PR TITLE
gssoc ui

### DIFF
--- a/lib/programs screen/google_summer_of_code_screen.dart
+++ b/lib/programs screen/google_summer_of_code_screen.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+void main() {
+  runApp(MaterialApp(
+    home: GoogleSummerOfCodeScreen(),
+  ));
+}
+
 class GoogleSummerOfCodeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -13,64 +19,109 @@ class GoogleSummerOfCodeScreen extends StatelessWidget {
         children: [
           Padding(
             padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child: TextField(
-              decoration: InputDecoration(
-                hintText: 'Search',
-                prefixIcon: Icon(Icons.search),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(30.0),
-                ),
-                contentPadding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 20.0),
+            child: Padding(
+              padding: const EdgeInsets.only(top: 22, bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextField(
+                    decoration: InputDecoration(
+                      hintText: 'Search',
+                      prefixIcon: Icon(Icons.search),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(30.0),
+                      ),
+                      contentPadding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 20.0),
+                    ),
+                    onChanged: (value) {
+                      // Handle search input
+                    },
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 20),
+                    child: SizedBox(height: 10),
+                  ), // Adjust as needed
+                  Text(
+                    'Google Summer of Code is a global, online program focused on bringing new contributors into open source software development.',
+                    style: TextStyle(fontSize: 19,fontWeight: FontWeight.w600, color: const Color.fromARGB(255, 75, 40, 136)),
+                    
+                  ),
+                ],
               ),
-              onChanged: (value) {
-                // Handle search input
+            ),
+          ),
+          SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: () {
+                launch('https://summerofcode.withgoogle.com/programs/2024/projects');
               },
+              style: ElevatedButton.styleFrom(
+                padding: EdgeInsets.symmetric(vertical: 20.0, horizontal: 40.0),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                ),
+              ),
+              icon: Icon(Icons.assignment),
+              label: Text('View Projects(2024)'),
             ),
           ),
           SizedBox(height: 20),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              YearButton(
-                year: '2021',
-                url: 'https://summerofcode.withgoogle.com/archive/2021/organizations', // Replace with actual URL
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: () {
+                launch('https://summerofcode.withgoogle.com/programs/2024/organizations');
+              },
+              style: ElevatedButton.styleFrom(
+                padding: EdgeInsets.symmetric(vertical: 20.0, horizontal: 40.0),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                ),
               ),
-              YearButton(
-                year: '2022',
-                url: 'https://summerofcode.withgoogle.com/archive/2022/organizations', // Replace with actual URL
-              ),
-            ],
-          ),
-          SizedBox(height: 20),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              YearButton(
-                year: '2023',
-                url: 'https://summerofcode.withgoogle.com/archive/2023/organizations', // Replace with actual URL
-              ),
-              YearButton(
-                year: '2024',
-                url: 'https://summerofcode.withgoogle.com/archive/2024/organizations', // Replace with actual URL
-              ),
-            ],
-          ),
-          SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: () {
-              // launch('https://example.com/projects'); // Replace with actual URL
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Color.fromARGB(255, 226, 230, 120), // Set button color
-              padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
+              icon: Icon(Icons.business),
+              label: Text('View Organizations(2024)'),
             ),
-            child: Text('View Projects'),
           ),
+          buildPastProgramsText(),
+          SizedBox(height: 10),
+          buildYearButtonsRow(['2020', '2021']),
+          SizedBox(height: 30),
+          buildYearButtonsRow(['2022', '2023']),
         ],
       ),
     );
   }
+
+  Widget buildPastProgramsText() {
+    return Container(
+      margin: EdgeInsets.only(left: 55, top: 30, bottom: 15),
+      child: Text(
+        'Past Programs:',
+        textAlign: TextAlign.left,
+        style: TextStyle(
+          fontSize: 22,
+          fontWeight: FontWeight.bold,
+          color: Colors.blue.shade900,
+        ),
+      ),
+    );
+  }
+
+  Widget buildYearButtonsRow(List<String> years) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: years.map((year) {
+        return YearButton(
+          year: year,
+          url: 'https://summerofcode.withgoogle.com/archive/$year/organizations',
+        );
+      }).toList(),
+    );
+  }
 }
+
 
 class YearButton extends StatelessWidget {
   final String year;
@@ -82,19 +133,17 @@ class YearButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       onPressed: () {
-        // ignore: deprecated_member_use
-        // launch(url);
+        launch(url);
       },
       style: ElevatedButton.styleFrom(
-        backgroundColor: Color.fromARGB(255, 172, 207, 236), // Set button color
+        backgroundColor: Color.fromARGB(255, 172, 207, 236),
+        padding: EdgeInsets.symmetric(vertical: 20.0, horizontal: 50.0),
       ),
-      child: Text(year),
+      child: Text(
+        year,
+        style: TextStyle(fontSize: 18), 
+      ),
     );
   }
 }
 
-void main() {
-  runApp(MaterialApp(
-    home: GoogleSummerOfCodeScreen(),
-  ));
-}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,10 +130,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
+      sha256: "7068716403343f6ba4969b4173cbf3b84fc768042124bc2c011e5d782b24fe89"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.5"
+    version: "6.3.0"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.0
+  flutter_lints: ^4.0.0
   flutter_launcher_icons: ^0.13.1
   awesome_notifications: ^0.9.3+1
 


### PR DESCRIPTION
#78 
- Adding organizations' list in GSOC 

Problem:
when you open gsoc site, they provide you with two lists, one of organizations and the other of projects, so adding the option of organizations list would make the app more easy to use and user can easily search through their interests

Changes:
Changed the Ui and added an onpressed organistaions' button that shows you the organisations' list



## Screenshots
![gsoc](https://github.com/andoriyaprashant/OpSo/assets/144620204/b8ad7bec-1091-4ab4-a3ec-678b6e10c4a9)
![WhatsApp Image 2024-05-16 at 21 59 34_3657cb27](https://github.com/andoriyaprashant/OpSo/assets/144620204/24b1c3c6-abac-4f54-ad60-e66394224749)


