### PR TITLE
Fixed the search option for the dark mode screen of Summer of Bitcoin Page

### DIFF
--- a/lib/programs screen/summer_of_bitcoin.dart
+++ b/lib/programs screen/summer_of_bitcoin.dart
@@ -126,7 +126,6 @@ class _SummerOfBitcoinState extends State<SummerOfBitcoin> {
                     TextFormField(
                       decoration: InputDecoration(
                         filled: true,
-                        fillColor: const Color(0xFFEEEEEE),
                         hintText: 'Search',
                         suffixIcon: const Icon(Icons.search),
                         enabledBorder: OutlineInputBorder(
@@ -157,7 +156,6 @@ class _SummerOfBitcoinState extends State<SummerOfBitcoin> {
                             vertical: 12.0, horizontal: 20.0),
                       ),
                       onFieldSubmitted: (value) {
-                        print("value is $value");
                         search(value.trim());
                       },
                       onChanged: (value) {


### PR DESCRIPTION
#122 

## Fixed the search option for the dark mode screen of Summer of Bitcoin Page

## Screenshots
<img src="https://github.com/andoriyaprashant/OpSo/assets/98171392/e79b112b-364a-4368-b2d0-535e40467269" width="200" height="400">


