### PR TITLE
Added the feature to auto comment on pull request being raised

### DIFF
--- a/.github/workflows/auto-comment-pr-raise.yml
+++ b/.github/workflows/auto-comment-pr-raise.yml
@@ -1,0 +1,36 @@
+name: Auto Comment on PR
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Add Comment to Pull Request
+      run: |
+        COMMENT=$(cat <<EOF
+        {
+          "body": "Thank you for submitting your pull request! We'll review it as soon as possible."
+        }
+        EOF
+        )
+        RESPONSE=$(curl -s -o response.json -w "%{http_code}" \
+          -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+          -d "$COMMENT")
+        cat response.json
+        if [ "$RESPONSE" -ne 201 ]; then
+          echo "Failed to add comment"
+          exit 1
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem / Issue No.
Closes #139 

## Describe Problem / Root Cause
This feature aims to address the problem of delayed and inconsistent communication following the raising of PRs. By automatically commenting on PRs as soon as they are raised, it ensures that contributors receive immediate feedback and acknowledgment for their efforts. 

## Solution proposed
I have added auto-comment-pr-raise.yml in .github/workflows directory. This file will add the feature of auto commenting when a pr is raised.
