### PR TITLE
Fixed bug of back button

### DIFF
--- a/lib/landing_page.dart
+++ b/lib/landing_page.dart
@@ -82,10 +82,10 @@ class _LandingPageState extends State<LandingPage> {
                             borderRadius: BorderRadius.all(Radius.circular(20)),
                           )),
                       onPressed: () {
-                        Navigator.push(
+                        Navigator.pushReplacement(
                             context,
                             MaterialPageRoute(
-                                builder: (context) => HomePage()));
+                                builder: (context) => const HomePage()));
                       },
                       child: Text(
                         "Get started",


### PR DESCRIPTION
## Problem / Issue No.
- Closes #222


## Describe Problem / Root Cause
- When we press back button on HomePage it navigates back to Landing page. I think this should not be the flow. It should exit the app directly. 