### PR TITLE
changed the filter row and placed it into the search bar

### DIFF
--- a/lib/programs screen/social_winter_of_code.dart
+++ b/lib/programs screen/social_winter_of_code.dart
@@ -246,21 +246,6 @@ class _SWOCScreenState extends State<SWOCScreen> {
                       _buildSearchBar(),
                       const SizedBox(height: 20),
                       _buildYearButtons(),
-                      const SizedBox(height: 20),
-                      _buildMultiSelectField(
-                        items: allLanguages,
-                        selectedValues: selectedLanguages,
-                        title: "Select Languages",
-                        buttonText: "Filter by Language",
-                        onConfirm: (results) {
-                          setState(() {
-                            selectedLanguages = results.isNotEmpty ? results : ['All'];
-                            filterProjects();
-                          });
-                        },
-                      ),
-                      const SizedBox(height: 20),
-                      const SizedBox(height: 20),
                       _buildProjectList(height, width),
                     ],
                   ),
@@ -281,7 +266,71 @@ class _SWOCScreenState extends State<SWOCScreen> {
       decoration: InputDecoration(
         filled: true,
         hintText: 'Search',
-        suffixIcon: const Icon(Icons.search),
+        suffixIcon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.filter_alt_outlined),
+              onPressed: () {
+                // Open the filter options (multi-select dialog)
+                showDialog(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: const Text("Filter Options"),
+                      content: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _buildMultiSelectField(
+                            items: allLanguages,
+                            selectedValues: selectedLanguages,
+                            title: "Select Languages",
+                            buttonText: "Filter by Language",
+                            onConfirm: (results) {
+                              setState(() {
+                                selectedLanguages =
+                                    results.isNotEmpty ? results : ['All'];
+                                filterProjects();
+                              });
+                            },
+                          ),
+                          const SizedBox(height: 20),
+                          _buildMultiSelectField(
+                            items: allOrganizations,
+                            selectedValues: selectedOrganizations,
+                            title: "Select Organizations",
+                            buttonText: "Filter by Organization",
+                            onConfirm: (results) {
+                              setState(() {
+                                selectedOrganizations =
+                                    results.isNotEmpty ? results : ['All'];
+                                filterProjects();
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                          child: const Text("Close"),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: () {
+                // Trigger search functionality
+              },
+            ),
+          ],
+        ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(10),
           borderSide: const BorderSide(color: Color(0xFFEEEEEE)),
@@ -298,12 +347,14 @@ class _SWOCScreenState extends State<SWOCScreen> {
           borderRadius: BorderRadius.circular(10),
           borderSide: const BorderSide(color: Color(0xFFEEEEEE)),
         ),
-        contentPadding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 20.0),
+        contentPadding:
+            const EdgeInsets.symmetric(vertical: 12.0, horizontal: 20.0),
       ),
       onFieldSubmitted: (value) {
         setState(() {
           projectList = _getProjectsByYear()
-              .where((project) => project.name.toLowerCase().contains(value.toLowerCase()))
+              .where((project) =>
+                  project.name.toLowerCase().contains(value.toLowerCase()))
               .toList();
         });
       },


### PR DESCRIPTION
## Problem / Issue No.
#321 



## Describe Problem / Root Cause
The current filter functionality is placed below the search bar, which can clutter the UI and disrupt the visual flow. To improve the design and provide a cleaner, more modern look, the filter options will be moved to an icon placed directly within the search bar. This solution simplifies the layout, reduces visual noise, and enhances user experience by making the filtering functionality more accessible without taking up additional space on the screen.


## Solution proposed
Add a Filter Icon Inside the Search Bar:

Place a filter icon (Icons.filter_list) next to the search icon inside the search bar.
This allows users to access filtering options without leaving the search bar, improving usability.
Trigger the Filter Dialog on Icon Click:

When the filter icon is clicked, a dialog or bottom sheet should open to display the filter options, providing an intuitive and modern interaction.
Implementation:

Modify the existing search bar widget to include the filter icon.
Move the filter logic (e.g., language, organization) to a dialog that pops up when the user clicks on the filter icon







## Screenshots
- Original Screenshot (Problem/Issue)
![image](https://github.com/user-attachments/assets/8d495a6d-2edc-4692-9dd2-aa882acb630d)

- Updated Screenshot (Fixes/Solution)
- 
![WhatsApp Image 2024-10-03 at 12 51 25_854fc385](https://github.com/user-attachments/assets/0799ffa4-f706-43ad-9344-089600c1a12c)
![WhatsApp Image 2024-10-03 at 12 51 25_760e0a27](https://github.com/user-attachments/assets/31a30e8d-7cf4-4808-82a3-9493fe770e8b)
![WhatsApp Image 2024-10-03 at 12 51 24_59860165](https://github.com/user-attachments/assets/af626faa-53c3-45b8-9c53-9d34e8e5db71)


