### PR TITLE
(feat) Added Application and Contribution periods for the GSSoC '24 Extd Program

### DIFF
--- a/lib/opso_timeline.dart
+++ b/lib/opso_timeline.dart
@@ -123,6 +123,18 @@ class OpsoTimeLineScreen extends StatelessWidget {
         'startDate': DateTime.utc(2024, 10, 1),
         'endDate': DateTime.utc(2024, 10, 31),
       },
+      {
+        'description':
+        "GirlScript Summer Of Code Extended\nApplication Period - 15/09/2024 to 10/10/2024",
+        'startDate': DateTime.utc(2024, 9, 15),
+        'endDate': DateTime.utc(2024, 10, 10),
+      },
+      {
+        'description':
+        "GirlScript Summer Of Code Extended\nContribution Period - 01/10/2024 to 30/10/2024",
+        'startDate': DateTime.utc(2024, 10, 1),
+        'endDate': DateTime.utc(2024, 10, 30),
+      },
     ];
 
     for (var event in events) {


### PR DESCRIPTION
# (feat) Added Application and Contribution periods for the GSSoC '24 Extd Program 

## Problem / Issue No.
Closes issue #330



## Describe Problem / Root Cause
The problem is that this project takes part of **GSSoC '24 Extd** program yet does not have it listed under the **_Open-Source Timeline of 2024_** section of the app.



## Solution proposed
In my code, I have added a total of **two** sections for the GSSoC program, one for the application period and the other for the contribution period. I have clearly listed my sources in the issue, refer to them as needed.

>[!NOTE]
>As previously mentioned in the issue, I am a GSSoC '24 Extd and hacktoberfest contributor, so please add both labels to the issue, pull request and project.


## Screenshots
- Original Screenshot (Problem/Issue)
![image](https://github.com/user-attachments/assets/15135195-4d3d-4b6e-90a8-b5589b3adeae)

- Updated Screenshot (Fixes/Solution)
![image](https://github.com/user-attachments/assets/4c35bce4-18e1-4c59-b74f-f5a1729f938b)


