### PR TITLE
bookmark updated successfully

### DIFF
--- a/lib/widgets/book_mark_screen.dart
+++ b/lib/widgets/book_mark_screen.dart
@@ -58,6 +58,7 @@ class _BookMarkScreenState extends State<BookMarkScreen> {
 
                   ),
                   onTap: () {
+                    Navigator.pushNamed(context, bookmark['screen']!);
                   },
                 );
               },


### PR DESCRIPTION
## Problem / Issue No.
BUG: title alignment issue in the appbar #346



## Describe Problem / Root Cause
the titles of all the pages are not aligned in center and also for moving back the default back arrow is used rather a customized ios arrow should be used to enhance the UI of application.



## Solution proposed
improved the opening of bookmarked tabs to make them more user friendly and enhance user engagement.



## Additional Information
- Relevant information regarding the solution.



## Screenshots
- Original Screenshot (Problem/Issue)
- Updated Screenshot (Fixes/Solution)

https://github.com/user-attachments/assets/f8a0e65c-0f4d-48c5-b6b9-291f329d1228


