### PR TITLE
Add Dynamic Contributors Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ Good documentation is essential for the success of any open-source project. If y
 
 <hr>
 
+## Contributors ✨
+
+Thanks to these amazing people for contributing to the project:
+
+<!-- Contributors list generated dynamically -->
+<a href="https://github.com/andoriyaprashant/OpSo/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=andoriyaprashant/OpSo" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
 <!-- Code of conduct -->
 <div>
 <h2><img src = "https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Hand%20gestures/Handshake.png" width="35" height="35"> Code of Conduct</h2>


### PR DESCRIPTION
## Problem / Issue No.
Adding a "Contributors" section that dynamically displays profile photos of all contributors

## Describe Problem / Root Cause
This change promotes visibility for all contributors, recognizing their efforts and encouraging more community involvement in the project.



## Solution proposed
This pull request enhances the README file by adding a "Contributors" section that dynamically displays profile photos of all contributors using [contrib.rocks](https://contrib.rocks/).



## Additional Information
Integrated a contributors section at the end of the README, which showcases all contributors with profile images linked to their GitHub profiles. This section is generated automatically, ensuring it's up-to-date as new contributors join the project.



## Screenshots
- Original Screenshot (Problem/Issue)
![oldss](https://github.com/user-attachments/assets/81775f27-394c-460e-9c94-0f5eb96d159b)

- Updated Screenshot (Fixes/Solution)
![newss](https://github.com/user-attachments/assets/4e15bf3b-d04b-4d03-bf74-1dce1fb51e71)


