### PR TITLE
[fix] Extended the Application Period for GSSoC Program to 25/10.

### DIFF
--- a/lib/opso_timeline.dart
+++ b/lib/opso_timeline.dart
@@ -125,9 +125,9 @@ class OpsoTimeLineScreen extends StatelessWidget {
       },
       {
         'description':
-        "GirlScript Summer Of Code Extended\nApplication Period - 15/09/2024 to 10/10/2024",
+        "GirlScript Summer Of Code Extended\nApplication Period - 15/09/2024 to 25/10/2024",
         'startDate': DateTime.utc(2024, 9, 15),
-        'endDate': DateTime.utc(2024, 10, 10),
+        'endDate': DateTime.utc(2024, 10, 25),
       },
       {
         'description':


### PR DESCRIPTION
## Problem / Issue No.
This PR addresses issue #352.



## Describe Problem / Root Cause
As mentioned in the issue, this PR is regarding updating the **Application Period** for the GSSoC _(GirlScript Summer of Code)_ program to the date **25th of October** as per their announcements.



## Solution proposed
Changed the duration in `text` and `endDate` for the **Application Period** Block.


## Screenshots
- Original Screenshot (Problem/Issue)
 
![image](https://github.com/user-attachments/assets/65d6292c-fdbb-4afb-a792-2f134dd62fff)

- Updated Screenshot (Fixes/Solution)

![image](https://github.com/user-attachments/assets/de939751-002a-4035-adb6-4adef7885862)




