### PR TITLE
[Fix] Change starting number from 0 to 1

### DIFF
--- a/lib/programs screen/fossasia.dart
+++ b/lib/programs screen/fossasia.dart
@@ -323,7 +323,7 @@ class _FOSSASIAState extends State<FOSSASIA> {
                                 modal: projectList[index],
                                 height: ScreenUtil().screenHeight * 0.2,
                                 width: ScreenUtil().screenWidth,
-                                index: index,
+                                index: index+1,
                               ),
                             );
                           },

--- a/lib/programs screen/hyperledger.dart
+++ b/lib/programs screen/hyperledger.dart
@@ -291,7 +291,7 @@ class _HyperledgerState extends State<Hyperledger> {
                                 modal: projectList[index],
                                 height: ScreenUtil().screenHeight * 0.2,
                                 width: ScreenUtil().screenWidth,
-                                index: index,
+                                index: index+1,
                               ),
                             );
                           },

--- a/lib/programs screen/redox.dart
+++ b/lib/programs screen/redox.dart
@@ -180,7 +180,7 @@ class _RsocPageState extends State<RsocPage> {
                                 modal: projectList[index],
                                 height: ScreenUtil().screenHeight * 0.10, 
                                 width: ScreenUtil().screenWidth,
-                                index: index,
+                                index: index+1,
                               ),
                             );
                           },

--- a/lib/programs screen/season_of_kde.dart
+++ b/lib/programs screen/season_of_kde.dart
@@ -267,7 +267,7 @@ class _SeasonOfKDEState extends State<SeasonOfKDE> {
                                 modal: projectList[index],
                                 height: ScreenUtil().screenHeight * 0.2,
                                 width: ScreenUtil().screenWidth,
-                                index: index,
+                                index: index+1,
                               ),
                             );
                           },


### PR DESCRIPTION
## Problem / Issue No.
This PR addresses issue #355


## Describe Problem / Root Cause
The index numbers being displayed in 4 pages were starting from 0.



## Solution proposed
Corrected this bug to ensure that index numbers start from 1. 


## Screenshots
- Original Screenshot (Problem/Issue)
![WhatsApp Image 2024-10-11 at 18 10 26_08d64936](https://github.com/user-attachments/assets/6361edd9-4465-4336-aab9-266a68c29105)
![WhatsApp Image 2024-10-11 at 18 10 26_8ec05210](https://github.com/user-attachments/assets/08f75ac8-ac25-46cf-b59f-33a9cc3fe245)

- Updated Screenshot (Fixes/Solution)
![image](https://github.com/user-attachments/assets/f13724a4-b7a7-4509-ad84-45496a15758b)
![image](https://github.com/user-attachments/assets/491226ef-5ecb-4cca-9a90-bef0eaa5359f)

![image](https://github.com/user-attachments/assets/2d529117-4615-4151-83f1-6d3d6e86a76b)
![image](https://github.com/user-attachments/assets/9f05f36d-a579-4b96-ad2e-bc000afcca23)


Please review and let me know if there are further changes!
