### PR TITLE
Able to preview the logo

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,6 +115,8 @@ flutter:
     - assets/projects/outreachy/outreachy2024.json
     - assets/projects/redox/redox.json
     - assets/no-results.png
+    - assets/projects/osoc/osoc2021.json
+    - assets/projects/osoc/osoc2022.json
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
## Problem / Issue No.
#360 



## Describe Problem / Root Cause
- Unable to preview of logo of LYNX Local Linked Taxes in the Summer of Code it is shown black while opening the Application.



## Solution proposed
- I have added the some dependencies in pubspec.yaml


Please merge my pull request @andoriyaprashant 

