### PR TITLE
Fixed corrupted svg not loading at Open summer of code

### DIFF
--- a/lib/widgets/osoc_widget.dart
+++ b/lib/widgets/osoc_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:opso/modals/osoc_modal.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:jovial_svg/jovial_svg.dart';
 
 class OsocWidget extends StatelessWidget {
   final OsocModal modal;
@@ -15,6 +16,7 @@ class OsocWidget extends StatelessWidget {
     final isDarkMode = Theme.of(context).brightness == Brightness.dark;
     final textColor = isDarkMode ? Colors.white : Colors.black;
     final cardColor = isDarkMode ? Colors.grey.shade800 : Colors.white;
+
     return GestureDetector(
       onTap: () => launchUrl(
         Uri.parse(modal.project_url),
@@ -32,9 +34,16 @@ class OsocWidget extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            SvgPicture.network(
-              modal.image_url,
-              height: height * 0.5,
+            ClipRRect(
+              borderRadius: BorderRadius.circular(50),
+              child: SizedBox(
+                height: 100,
+                width: 100,
+                child: ScalableImageWidget.fromSISource(
+                    si: ScalableImageSource.fromSvgHttpUrl(
+                  Uri.parse(modal.image_url),
+                )),
+              ),
             ),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
@@ -256,6 +264,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  jovial_misc:
+    dependency: transitive
+    description:
+      name: jovial_misc
+      sha256: f6e64f789ee311025bb367be9c9afe9759f76dd8209070b7f38e735b5f529eb1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.5"
+  jovial_svg:
+    dependency: "direct main"
+    description:
+      name: jovial_svg
+      sha256: adbc985f89a9e9c601d29aebb9fc17dd0a5db05b67af7e6c21da91eeb13dacb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.23"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -392,6 +424,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -633,10 +673,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
+      sha256: "68d1e89a91ed61ad9c370f9f8b6effed9ae5e0ede22a270bdfa6daf79fc2290a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.5.4"
   xdg_directories:
     dependency: transitive
     description:
@@ -662,5 +702,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.3 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   flutter_svg: ^2.0.10+1
   flutter_screenutil: ^5.9.1
   multi_select_flutter: ^4.1.3
+  jovial_svg: ^1.1.23
 dev_dependencies:
   awesome_notifications: ^0.9.3+1
   flutter_launcher_icons: ^0.13.1


### PR DESCRIPTION
- #410 

This pull request includes updates to the `OsocWidget` to improve the handling of SVG images and enhance the UI. The most important changes involve adding a new dependency, updating the widget to use a new SVG handling package, and making UI adjustments.

### Dependency Updates:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R48): Added `jovial_svg` dependency to the project.

### Widget Updates:
* [`lib/widgets/osoc_widget.dart`](diffhunk://#diff-4422cab2e2f5d40fbf9f9454f9ce1cea2a8d27c8dca8e1b9ff2a0d86073fd210R5): Imported the `jovial_svg` package.
* [`lib/widgets/osoc_widget.dart`](diffhunk://#diff-4422cab2e2f5d40fbf9f9454f9ce1cea2a8d27c8dca8e1b9ff2a0d86073fd210L35-R46): Updated the `OsocWidget` to use `ScalableImageWidget` from `jovial_svg` for displaying SVG images, replacing the previous `SvgPicture.network` implementation. This includes wrapping the image in a `ClipRRect` with rounded corners and setting fixed dimensions.

### Screenshot
https://github.com/user-attachments/assets/2c8d49b9-c333-4aef-9daa-b6bf269dcb66

