### PR TITLE
Add GSoC 2025 organization and project datasets

### DIFF
--- a/assets/projects/gsoc_projects/gsoc25projects.json
+++ b/assets/projects/gsoc_projects/gsoc25projects.json
@@ -1,0 +1,4208 @@
+[
+  {
+    "name": "52°North Spatial Information Research GmbH",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/52north-spatial-information-research-gmbh/gzamo2sqfwcmcobt-360.png",
+    "image_background_color": null,
+    "description": "52°North is an open source initiative in the field of geoinformatics. Core topics of our activities are for example sensor web, web-based geoprocessing and earth observation.",
+    "url": "https://52north.org/",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "citizen science",
+      "spatial information infrastructures",
+      "open standards",
+      "data analytics",
+      "Geoinformation"
+    ],
+    "technologies": [
+      "javascript",
+      "android",
+      "java",
+      "web services",
+      "ogc standards"
+    ],
+    "contact_email": "gsoc@52north.org",
+    "projects_url": "https://52north.org/outreach-dissemination/google-summer-of-code/project-ideas/"
+  },
+  {
+    "name": "AboutCode",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/aboutcode/v8yhhmpej4djujai-360.png",
+    "image_background_color": null,
+    "description": "AboutCode.org is a community of open source developers who are trying to make open source easier to use by providing open source tools to discover, identify and track open source components (aka. Software Composition Analysis – SCA). This includes tools, data and standards for code origin, FOSS licenses and security vulnerabilities.",
+    "url": "https://aboutcode.org",
+    "category": "Security, Development tools",
+    "topics": [
+      "dependencies",
+      "vulnerabilities",
+      "SoftwareCompositionAnalysis",
+      "License",
+      "SBOM"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "Django+PostgreSQL",
+      "C/Rust/Go"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/aboutcode-org/aboutcode/wiki/GSOC-2026-project-ideas"
+  },
+  {
+    "name": "Accord Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/accord-project/1q3vpch01xpsriu9-360.png",
+    "image_background_color": null,
+    "description": "Accord Project champions the importance of contract text alongside computer-code when automating contracts. This is often referred to as Computable Contracts or Smart Legal Contracts.\n\nThe Accord Project is a non-profit, collaborative, initiative developing an ecosystem and open source tools for computational contracts. The community includes participants from law firms, technology companies, universities, government and private individuals.\n\nToday, the community maintains a technology neutral foundation for smart legal contracts, based on the union of legal text with a machine readable data model, and machine executable logic. This definition of a smart legal contract is recognised across the industry, including by statutory and standards bodies. \n\nAccord Project is a top-level Linux Foundation project.",
+    "url": "https://accordproject.org",
+    "category": "Programming languages, Artificial Intelligence",
+    "topics": [
+      "natural language processing",
+      "data modeling",
+      "legal technology",
+      "contract management",
+      "document assembly"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "json",
+      "react",
+      "artificial intelligence"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/accordproject/techdocs/wiki/Google-Summer-of-Code-2026-Ideas-List"
+  },
+  {
+    "name": "AFLplusplus",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/aflplusplus/dw8yelaswljerorz-360.png",
+    "image_background_color": null,
+    "description": "We are dedicated to provide the most effective fuzzing frameworks. Our work includes AFL++, the most effective and flexible fuzzer, and libafl, a library to build your own fuzzer with the most modern techniques and technologies.",
+    "url": "https://aflplus.plus",
+    "category": "Security",
+    "topics": [
+      "fuzzing",
+      "ci"
+    ],
+    "technologies": [
+      "llvm",
+      "rust",
+      "fuzzing",
+      "qemu"
+    ],
+    "contact_email": "afl@aflplus.plus",
+    "projects_url": "https://github.com/AFLplusplus/LibAFL/issues/3706"
+  },
+  {
+    "name": "Alaska",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/alaska/uuu8lxevgc3jof9c.png",
+    "image_background_color": null,
+    "description": "Alaska Project Ideas are mentored by the researchers and collaborators of the University of Alaska and supported by other open-source entities in Alaska, such as Alaska Dev Alliance.\n\nWe aim to represent the open-source ecosystem of the 49th state, Alaska. Anchorage, the largest city in Alaska, has a vibrant open-source community. Through this GSoC initiative, industrial experts who are part of the Alaska Developer Alliance and faculty and researchers from the University of Alaska Anchorage (UAA) and the University of Alaska Fairbanks (UAF) join hands to provide a perfect mentoring experience for interested contributors globally. We offer a glimpse of this northern state and its tech landscape to the Lower 48 and the outside world through this open-source remote summer coding program organized and funded by Google. Our projects focus on healthcare, climate science, polar science, and other research fields critical to the Circumpolar North and the rest of the world.",
+    "url": "https://www.uaa.alaska.edu/research",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "deep learning",
+      "neuroscience",
+      "radiology",
+      "heathcare",
+      "Polar Science"
+    ],
+    "technologies": [
+      "python",
+      "mysql",
+      "java",
+      "matlab",
+      "dicom"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/uaanchorage/GSoC"
+  },
+  {
+    "name": "AnkiDroid",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/ankidroid/cxtovrlsuuluttgi-360.png",
+    "image_background_color": null,
+    "description": "Memorize anything with AnkiDroid!<br/><br/>\n\nAnkiDroid lets you learn flashcards very efficiently by showing them just before you would forget. It is fully compatible with the spaced repetition software Anki (including synchronization), which is available for Windows/Mac/Linux/ChromeOS.<br/><br/>\n\nStudy all sorts of things wherever and whenever you want. Make good use of idle times on bus trips, in supermarket queues or any other waiting situation!<br/><br/>\n\nCreate your own flashcard decks or download free decks compiled for many languages and topics (more than 6000 available).<br/><br/>\n\nAdd material through the desktop application Anki or directly through AnkiDroid. The application even supports adding material automatically from a dictionary!<br/><br/>\n\n★ Key features:<br/>\n• supported flashcard contents: text, images, sounds, LaTeX & MathJax<br/>\n• spaced repetition (supermemo 2 algorithm)<br/>\n• text-to-speech integration<br/>\n• check your pronunciation<br/>\n• more than 6000 premade decks<br/>\n• progress widget<br/>\n• detailed statistics<br/>\n• syncing with AnkiWeb<br/>\n• open source",
+    "url": "https://github.com/ankidroid/Anki-Android",
+    "category": "End user applications",
+    "topics": [
+      "education",
+      "mobile",
+      "android",
+      "user generated content",
+      "Flashcards"
+    ],
+    "technologies": [
+      "android",
+      "rust",
+      "kotlin",
+      "mobile"
+    ],
+    "contact_email": "",
+    "projects_url": "https://docs.google.com/document/d/1ygIJl-Tp5_wJDKkSXrCC8h5K3WUG8D4BcJa_j70F0Zo"
+  },
+  {
+    "name": "AOSSIE",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/aossie/oo1wd34pc1ytrq6a-360.png",
+    "image_background_color": null,
+    "description": "We are an Australian not-for-profit charity, founded in 2016, that serves as an umbrella organization for open-source projects. We believe the open-source philosophy is a resource-efficient approach to transfer knowledge, educate and innovate. \n\nWe have almost 200 repositories in 3 GitHub spaces:\n* https://github.com/orgs/AOSSIE-Org (our main space)\n* https://github.com/StabilityNexus (for our blockchain projects)\n* https://github.com/DjedAlliance (for our stablecoin projects)\n\nOur projects span a wide range of topics and themes, including: financial stability, environmental sustainability, governance, trust, decentralized communication, artificial intelligence. The common ground under all our projects is our passion for making the world a better place, by empowering people with free software than can be run with minimal dependencies.\n\nWe have a diverse group of mentors, including GSoC students from previous years who decided to become long-term contributors as well as academics with extensive experience in supervising undergraduate, M.Sc. and PhD students on theses and projects, whose results are often published and presented in the most prestigious conferences of our research fields.",
+    "url": "https://www.aossie.org",
+    "category": "End user applications, Other",
+    "topics": [
+      "web",
+      "artificial intelligence",
+      "communication",
+      "mobile",
+      "blockchain"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "flutter",
+      "Blockchain",
+      "Solidity"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/AOSSIE-Org/Info/blob/main/GSoC-Ideas/2026/index.md"
+  },
+  {
+    "name": "Apache DataFusion",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/apache-datafusion/tqdstft3qk2yleu9-360.png",
+    "image_background_color": null,
+    "description": "DataFusion is an extensible query engine written in Rust that uses Apache Arrow as its in-memory format.\n\n“Out of the box,” DataFusion offers SQL and Dataframe APIs, excellent performance, built-in support for CSV, Parquet, JSON, and Avro, extensive customization, and a great community. Python Bindings are also available.\n\nDataFusion features a full query planner, a columnar, streaming, multi-threaded, vectorized execution engine, and partitioned data sources. You can customize DataFusion at almost all points including additional data sources, query languages, functions, custom operators and more.",
+    "url": "https://datafusion.apache.org/",
+    "category": "Data, Programming languages",
+    "topics": [
+      "databases",
+      "big data",
+      "OLAP"
+    ],
+    "technologies": [
+      "python",
+      "rust",
+      "sql",
+      "arrow"
+    ],
+    "contact_email": "",
+    "projects_url": "https://datafusion.apache.org/contributor-guide/gsoc_project_ideas"
+  },
+  {
+    "name": "Apache Software Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/apache-software-foundation/hq22fwtmvdfjnsh9-360.png",
+    "image_background_color": null,
+    "description": "The Foundation provides an established framework for intellectual property and financial contributions that simultaneously limits contributors potential legal exposure. Through a collaborative and meritocratic development process, Apache projects deliver enterprise-grade, freely available software products that attract large communities of users. The pragmatic Apache License makes it easy for all users, commercial and individual, to deploy Apache products.",
+    "url": "https://apache.org",
+    "category": "Web, Other",
+    "topics": [
+      "big data",
+      "cloud",
+      "libraries",
+      "other"
+    ],
+    "technologies": [
+      "c",
+      "java",
+      "c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://s.apache.org/gsoc2026ideas"
+  },
+  {
+    "name": "API Dash",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/api-dash/wgtarubdkvdp5qih-360.png",
+    "image_background_color": null,
+    "description": "API Dash is a beautiful open-source cross-platform (macOS, Windows, Linux, Android & iOS) API Client built using Flutter & powered by AI which can help you easily create & customize your HTTP, GraphQL, SSE & AI API requests, visually inspect responses and generate API integration code.\n\nThis season we are focussing on helping developers test MCP tools/servers, evaluating Multimodal AI APIs, and adding agentic AI features in API Dash.\n\nProject Tech stacks - React, Node, TypeScript, Flutter, Dart & Python.",
+    "url": "https://apidash.dev",
+    "category": "Development tools, Artificial Intelligence",
+    "topics": [
+      "api",
+      "developer tools",
+      "ai",
+      "Agents",
+      "MCP"
+    ],
+    "technologies": [
+      "python",
+      "react",
+      "flutter",
+      "typescript",
+      "ai"
+    ],
+    "contact_email": "ankit@apidash.dev",
+    "projects_url": "https://github.com/foss42/apidash/discussions/1054"
+  },
+  {
+    "name": "ArduPilot",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/ardupilot/oveqvcxkpgkuv8wq-360.png",
+    "image_background_color": null,
+    "description": "ArduPilot is the world's most widely used open source flight code software for unmanned autonomous vehicles including planes, multicopters, helicopters, cars, boats, submarines, blimps, antenna trackers and much more.\n\nWritten primarily in C++, ArduPilot supports over 100 different types of autopilot hardware including the well known Pixhawk autopilot.\n\nOur team motto, \"Versatile, Trusted, Open\" reflects our team's aim to provide high quality autopilot software that reliably supports a huge variety of frames, sensors and use cases.  The software is open but so is the team, always welcoming of new contributors whether they be software developers, wiki documentors, testers or users.",
+    "url": "https://ardupilot.org/",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "robotics",
+      "ai",
+      "Drone",
+      "autonomous vehicle",
+      "unmanned vehicle"
+    ],
+    "technologies": [
+      "python",
+      "lua",
+      "c++",
+      "pixhawk"
+    ],
+    "contact_email": "",
+    "projects_url": "https://ardupilot.org/dev/docs/gsoc-ideas-list.html"
+  },
+  {
+    "name": "AsyncAPI",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/asyncapi/gmnlfvngjaqxjxio.png",
+    "image_background_color": null,
+    "description": "AsyncAPI is an Open-Source tool to easily build and maintain your event-driven architecture. All are powered by the AsyncAPI specification, the industry standard for defining asynchronous APIs.",
+    "url": "https://www.asyncapi.com/",
+    "category": "Programming languages, Infrastructure and cloud",
+    "topics": [
+      "web",
+      "api",
+      "cloud",
+      "Architectures"
+    ],
+    "technologies": [
+      "javascript",
+      "java",
+      "go",
+      "typescript",
+      "RAML"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/asyncapi/community/blob/master/docs/050-mentorship-program/summer-of-code-2026-project-ideas.md"
+  },
+  {
+    "name": "BeagleBoard.org",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/beagleboardorg/4w6td6bjy31ei9v2-360.png",
+    "image_background_color": null,
+    "description": "Enabling individuals to define the connected devices in their lives, BeagleBoard.org is the open-source, community-driven hardware precursor to Raspberry Pi, continuing to improve performance, access and openness for embedded development. The community is diverse with many professional developers utilizing the open source designs to build production solutions. Supported by a non-profit foundation, the community seeks to improve access to technology for making embedded devices using open source software and hardware. On-going developments include open designs around DSP/AI/ML accelerators, RISC-V cores, FPGA-based open hardware developement, software-defined radios, robotics/motor control, privacy-oriented personal servers, musical instruments, lighting displays, and open standards that simplify and clarify embedded systems technology.",
+    "url": "https://www.beagleboard.org",
+    "category": "Science and medicine, Infrastructure and cloud",
+    "topics": [
+      "robotics",
+      "iot",
+      "ai",
+      "software defined radio",
+      "Personal Server"
+    ],
+    "technologies": [
+      "linux",
+      "fpga",
+      "risc-v",
+      "dsp",
+      "Zephyr RTOS"
+    ],
+    "contact_email": "gsoc@beagleboard.org",
+    "projects_url": "https://gsoc.beagleboard.org/ideas/"
+  },
+  {
+    "name": "Blender Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/blender-foundation/b3isfbjn0avwbmmf-360.png",
+    "image_background_color": null,
+    "description": "Blender is a free and open source 3D creation suite, providing individuals and small teams a complete pipeline for 3D graphics, modeling, animation and games.\n\nBlender is being made by 100s of active volunteers from all around the world; by studios and individual artists, professionals and hobbyists, scientists and students, vfx experts and animators, and so on.  All of them are united by an interest to have access to a fully free/open source 3D creation pipeline. Blender Foundation supports and facilitates these goals - even employs a staff for that - but fully depends on the online community to achieve it.",
+    "url": "https://www.blender.org",
+    "category": "End user applications, Media",
+    "topics": [
+      "games",
+      "graphics",
+      "3d",
+      "rendering",
+      "animation"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "opengl",
+      "c++",
+      "vulkan"
+    ],
+    "contact_email": "",
+    "projects_url": "https://developer.blender.org/docs/programs/gsoc/ideas/"
+  },
+  {
+    "name": "BRL-CAD",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/brl-cad/4ec07aqdfrvygfed-360.png",
+    "image_background_color": null,
+    "description": "<p>This is the place to be if you love computer graphics.  We do 2D/3D modeling, 3D printing, solid geometry, design, and more.  Depending on the project, you have the opportunity to work with C/C++, Python, OpenGL, OpenCL, Qt, Javascript, and more...  Help us develop open source computer-aided technologies (CAx)!</p>\n<br>\n<p>We operates as an umbrella organization with several CAx communities including:</p>\n<br>\n<ul>\n<li> - OpenSCAD is a solid 3D modeler with a rich syntax for programmable geometry.\n<li> - LibreCAD is a 2D modeling system specializing in blueprint-style drawings and draftings.\n<li> - IfcOpenShell is a library for working with standard IFC building model data.\n<li> - BRL-CAD is a solid modeling suite with conversion and advanced solid ray tracing features.\n<li> - Manifold is a solid geometry mesh processing library.\n</ul>\n<br>\n<p>We want to select at least one student for each, so feel free to ask us where to start.</p>\n<br>\n<a href=\"https://opencax.github.io\"><img src=\"https://summerofcode.withgoogle.com/media/org/brl-cad/4ec07aqdfrvygfed-360.png\"></a>",
+    "url": "https://opencax.github.io/",
+    "category": "Media, Artificial Intelligence",
+    "topics": [
+      "geometry",
+      "2d/3d graphics",
+      "ray tracing",
+      "high-performance computing",
+      "deep neural net rendering"
+    ],
+    "technologies": [
+      "python",
+      "c/c++",
+      "opengl",
+      "opencl",
+      "scripting"
+    ],
+    "contact_email": "devs@brlcad.org",
+    "projects_url": "https://github.com/opencax/GSoC/issues?q=is%3Aissue+is%3Aopen+label%3A%22GSoC+2026%22"
+  },
+  {
+    "name": "cBioPortal for Cancer Genomics",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/cbioportal-for-cancer-genomics/fdxtjhb0urtqcyfe-360.png",
+    "image_background_color": null,
+    "description": "The cBioPortal for Cancer Genomics is a resource designed to provide broad community access to cancer genomic data. It provides a unique user­-friendly and \"biology­-centric computational user interface\", with the goal of making genomic data more easily accessible to translational scientists, biologists, and clinicians. The interface was explicitly built and continues to evolve with careful usability studies involving multiple biological and clinical users, and an active and engaged user base.\n\nThe public instance of cBioPortal (https://cbioportal.org/) is one of the most popular online resources for cancer genomics data and attracts more than 3,000 unique visitors (cancer researchers and clinicians) per day. The three papers documenting the cBioPortal: Cerami et al. Cancer Discov. 2012; Gao et al. Sci. Signal. 2013; and de Bruijn et al. Cancer Res. 2023; have been cited more than 16,000, 17,000, and 800 times, respectively. There are more than 100 actively used cBioPortal instances in hospitals, universities, pharmaceutical companies, and other institutes around the globe.\n\nWe are a group of software engineers, bioinformaticians, and cancer biologists building software solutions for precision medicine for cancer patients. Our overall goal is to build infrastructure to support clinical decisions for personalized cancer treatment by utilizing “big data” of cancer genomics and patient clinical profiles. Our multi-institutional team currently has more than 30 active members, primarily from Memorial Sloan Kettering Cancer Center,  the Dana-Farber Cancer Institute, Princess Margaret Cancer Centre, Children's Hospital of Philadelphia, and The Hyve, a bioinformatics company from the Netherlands.",
+    "url": "https://www.cbioportal.org/",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "genomics",
+      "cancer",
+      "bioinformatics",
+      "big data",
+      "precision medicine"
+    ],
+    "technologies": [
+      "mysql",
+      "javascript",
+      "java",
+      "react",
+      "typescript"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/cBioPortal/GSoC/issues?q=is%3Aissue%20state%3Aopen%20label%3AGSoC-2026"
+  },
+  {
+    "name": "CCExtractor Development",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/ccextractor-development/xjqt8fksfnyqyqrd-360.png",
+    "image_background_color": null,
+    "description": "CCExtractor Development is the creator of the de-facto captions extraction tool - CCExtractor. It is the one tool that is free, portable, open source and community managed that can take a recording from a TV show and generate an external subtitle file for it.\n\nIf you regularly watch content with subtitles you download from fan sites - you should know that the source file is most likely generated by CCExtractor. If you are a student in a university that uses subtitles for natural language study, you should know that most likely we are involved somehow.\n\nWhile we already support subtitles from North America, Europe, Australia and more, our world map is not yet complete. We are actively looking for students that want to help us fill the gaps. We also want to automate many of the processes that are currently done manually, such as achieving perfect sync, our media file management.\n\nIn addition to continuously evolve our core tool, we have a growing number of new projects: support, AI, rclone, cloud, flutter, peer-to-peer and a few more that are starting to take shape.\n\nThe best part is - students have flexibility of choosing projects from a wide range of topics & technologies and even propose their own. We provide exceptional resources for students. Read more about the perks on our website.\n\nWe’re very excited to take part in GSoC for the 9th time. Most of our past students are still involved and are active in the community, which simply goes on to show how friendly and approachable is the environment. If you want to be a part of such community and help achieve our goals, come join our Slack group or mailing list!",
+    "url": "https://www.ccextractor.org",
+    "category": "End user applications, Media",
+    "topics": [
+      "vr",
+      "linux",
+      "video",
+      "subtitles",
+      "mobile"
+    ],
+    "technologies": [
+      "c",
+      "linux",
+      "rust",
+      "flutter"
+    ],
+    "contact_email": "gsoc@ccextractor.org",
+    "projects_url": "https://ccextractor.org/docs/ideas_page_for_summer_of_code_2026/"
+  },
+  {
+    "name": "Center for Translational Data Science",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/center-for-translational-data-science/bc61hj7tocvmpw6p-360.png",
+    "image_background_color": null,
+    "description": "We develop and operate large-scale data platforms to support research in topics of societal interest, including cancer, cardiovascular disease, inflammatory bowel disease (IBD), birth defects, veterans’ health, pain management, opioid use disorder, and environmental science. We also develop new machine learning and AI algorithms over the data in our platforms.",
+    "url": "https://ctds.uchicago.edu",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "machine learning",
+      "artificial intelligence",
+      "devops",
+      "MLOps",
+      "Data Meshes"
+    ],
+    "technologies": [
+      "golang",
+      "docker",
+      "postgres",
+      "gpu",
+      "LLMs"
+    ],
+    "contact_email": "ctds-jobs@lists.uchicago.edu",
+    "projects_url": "https://docs.google.com/document/d/15nJnNE43ybaGeqyHLuXDlbVCb36bCdi_A85QQH_mc7Q/edit?usp=sharing"
+  },
+  {
+    "name": "Ceph",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/ceph/rvqqprqtyq0rfrcc-360.png",
+    "image_background_color": null,
+    "description": "An open-source storage platform that implements storage on a single distributed computer cluster and provides a 3-in-1 interface for object-, block- and file-level storage.",
+    "url": "https://ceph.io/en/",
+    "category": "Data, Infrastructure and cloud",
+    "topics": [
+      "distributed systems",
+      "Software-Defined-Storage"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://ceph.io/en/developers/google-summer-of-code/"
+  },
+  {
+    "name": "CERN-HSF",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/cern-hsf/cjus658sjzba5zhg-360.png",
+    "image_background_color": null,
+    "description": "CERN-HSF (High-Energy Physics Software Foundation) is the umbrella organization for high-energy physics-related projects in GSoC. The HEP Software Foundation (http://hepsoftwarefoundation.org/) facilitates the coordination of common international efforts in high-energy physics software and computing.\n\nCERN (European Organization for Nuclear Research, https://home.cern) has participated in GSoC since 2011 as the CERN-SFT group, which provides common software for CERN's experiments. In 2017, the program expanded to include many software projects from the whole field of high-energy physics. The vast majority of our GSoC projects do not require any physics knowledge.\n\nThe experiments at CERN, such as the Large Hadron Collider, the world’s largest and most powerful particle accelerator (http://home.cern/topics/large-hadron-collider) try to answer fundamental questions about the Universe. For example, what is the nature of mass? What are the elementary building blocks of the Universe? What was the early Universe like? What is the nature of dark matter and dark energy? Why is there an asymmetry between matter and antimatter? In 2012, LHC experiments announced the discovery of a new particle, the Higgs Boson, that helps explain how particles obtain mass. Also, CERN is the birthplace of the World Wide Web. Today, particle physicists are working on analyzing the data from the experiments to study the properties of the newly discovered particle and to search for new physics, such as dark matter or extra dimensions. This requires a lot of sophisticated software.\n\nThe open-source high-energy physics projects to which students can contribute during GSoC span many high-energy physics software projects: data analysis, detector and accelerator simulation, event reconstruction, data management and many others. We look forward to your contributions!",
+    "url": "http://hepsoftwarefoundation.org/activities/gsoc.html",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "big data",
+      "algorithmics",
+      "particle physics",
+      "Performance Optimisation"
+    ],
+    "technologies": [
+      "python",
+      "c/c++",
+      "data analysis",
+      "artificial intelligence",
+      "container orchestration"
+    ],
+    "contact_email": "hsf-gsoc-admin@googlegroups.com",
+    "projects_url": "https://hepsoftwarefoundation.org/gsoc/2026/summary.html"
+  },
+  {
+    "name": "CGAL Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/cgal-project/9ubuadbe0eg5xfcw-360.png",
+    "image_background_color": null,
+    "description": "CGAL is a software library that offers a number of reliable geometric data structures and algorithms. CGAL components operate in 2D and 3D, and sometime in arbitrary dimensions. Examples of components include convex hulls, convex decomposition, Delaunay triangulations, Voronoi diagrams, polygonal surface mesh data-structures, mesh generation, Boolean operations, envelope computations, intersection detection, surface reconstruction, and subdivision surfaces.\n\nCGAL is used in a variety of application domains such as CAD/CAM (computer aided design and modeling), GIS (geographic information systems), geophysics, image processing, molecular biology, robotics, motion planning, and graphics.\n\nCGAL is written in C++ and rigorously adheres to the generic-programming paradigm.\n\nCGAL became an Open Source project in 2003. Most of CGAL is under the GPL v3+ license, and some core parts are under the LGPL v3+. The semi-annual releases have currently about 10,000 downloads. CGAL is commercially supported by the spin-off company GeometryFactory.",
+    "url": "https://www.cgal.org",
+    "category": "Science and medicine",
+    "topics": [
+      "geometry",
+      "mesh processing",
+      "computation geometry",
+      "geometry processing"
+    ],
+    "technologies": [
+      "c++",
+      "qt"
+    ],
+    "contact_email": "gsoc-cgal@inria.fr",
+    "projects_url": "https://github.com/CGAL/cgal/wiki/Project-Ideas"
+  },
+  {
+    "name": "CHAOSS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/chaoss/omnpzqtoqzjmesi7-360.png",
+    "image_background_color": null,
+    "description": "The importance of open source software is no longer in question and its importance raises important questions about how we understand the health of the open-source projects we rely on. Unhealthy projects can have negative impacts on the community involved in the project as well as organizations that rely on such projects. In response, people want to know more about the open-source projects they are engaged with. For example:\n\n1. Open source contributors want to know where they should place their efforts and know that they are making an impact.\n\n2. Open source communities want to attract new members, ensure consistent quality, and reward valuable members.\n3. Open source companies want to know which communities to engage with, communicate the impact the organization has on the community, and evaluate the work of their employees within open source.\n\nOpen source foundations want to identify and respond to community needs, evaluate the impact of their work, and promote communities.\nIn response to these issues, the CHAOSS project develops metrics, practices, and software for making open source project health more understandable. By building measures of open source project health, CHAOSS seeks to improve the transparency and actionability of open source project health so that relevant stakeholders can make more informed decisions about open source project engagement.\n\nThe project goals are to:\n1. Establish standard implementation-agnostic metrics for measuring community health\n\n2. Produce integrated open source software for analyzing software community development\n\n3. Develop programs for the deployment of metrics not attainable through online trace data\n\nBuild reproducible project health reports",
+    "url": "https://chaoss.community",
+    "category": "Data, Artificial Intelligence",
+    "topics": [
+      "open source software metrics",
+      "software sustainability",
+      "community building",
+      "security and software bill of materials"
+    ],
+    "technologies": [
+      "python",
+      "postgresql",
+      "javascript",
+      "machine learning",
+      "metrics"
+    ],
+    "contact_email": "gsoc@goggins.com",
+    "projects_url": "https://github.com/chaoss/augur/blob/main/gsoc-interest.md"
+  },
+  {
+    "name": "Checker Framework",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/checker-framework/zgooweugtqicf1jx-360.png",
+    "image_background_color": null,
+    "description": "We are a group of developers who are passionate about code quality.  We have built an innovative lightweight  tool called the Checker Framework (https://checkerframework.org/).\n\nThe Checker Framework helps you prevent bugs at development time, before they escape to production.  It is based on the idea of _pluggable type-checking_.  Pluggable type-checking augments a programming language's built-in type system with a more powerful, expressive one.\n\nJava's type system prevents some bugs, such as `int count = \"hello\";`.  However, it does not prevent other bugs, such as null pointer dereferences, concurrency errors, disclosure of private information, incorrect internationalization, out-of-bounds indices, etc.\n\nThe Checker Framework enables you to create a more powerful type system and use it in place of Java's.  The more powerful type system is not just a bug-finding tool:  it is a verification tool that gives a guarantee that no errors (of certain types) exist in your program.  Even though it is powerful, it is easy to use.  It follows the standard typing rules that programmers already know, and it fits into their workflow.  We have created around 20 new type systems, and other people have created many more.\n\nThe Checker Framework is popular:  it is successfully used on hundreds of projects at Amazon, Google, Meta, Uber, on Wall Street, and in other companies from big to small.  It it attractive to programmers who care about their craft and the quality of their code.  The Checker Framework is the motivation for Java's type annotations feature.  Talks on it have received multiple awards at conferences such as JavaOne.  With this widespread use, there is a need for people to help with the project:  everything from bug fixes, to new features, to case studies, to IDE integration.  We welcome your contribution!\n\nPlease see our ideas list (https://rawgit.com/typetools/checker-framework/master/docs/developer/new-contributor-projects.html) for how to get started and how to ask questions.",
+    "url": "https://checkerframework.org/",
+    "category": "Security, Development tools",
+    "topics": [
+      "software engineering",
+      "verification",
+      "bug finding",
+      "programmer productivity",
+      "type systems"
+    ],
+    "technologies": [
+      "java",
+      "compilers",
+      "Verification",
+      "formal methods",
+      "type systems"
+    ],
+    "contact_email": "checker-framework-gsoc@googlegroups.com",
+    "projects_url": "https://rawgit.com/typetools/checker-framework/master/docs/developer/new-contributor-projects.html"
+  },
+  {
+    "name": "checkstyle",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/checkstyle/e8ubktvaft8eljli-360.png",
+    "image_background_color": null,
+    "description": "Checkstyle is a development tool to help programmers write Java code that is easy to read and adheres to a coding standard. Our utility automates the process of checking Java code to spare humans of this boring (but important) task. This makes it ideal for projects that want to enforce a coding standard. Each and every check also forces our users who are not familiar with these standards to read them and makes them think about why these standards exist.",
+    "url": "https://checkstyle.org",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "static code analysis‎",
+      "code review tool",
+      "coding standards",
+      "coding conventions",
+      "artificial-intelligence"
+    ],
+    "technologies": [
+      "java",
+      "antlr",
+      "artificial-intelligence"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/checkstyle/checkstyle/wiki/Checkstyle-GSoC-2026-Project-Ideas"
+  },
+  {
+    "name": "Chromium",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/chromium-lj/qiwhezblvq2a0jgc-360.png",
+    "image_background_color": null,
+    "description": "The Chromium projects include Chromium and Chromium OS, the open-source projects behind the Google Chrome browser and Google Chrome OS, respectively.\n\nChromium is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.\n\nChromium OS is an open-source project that aims to provide a fast, simple, and more secure computing experience for people who spend most of their time on the web.",
+    "url": "https://chromium.org",
+    "category": "Operating systems, Web",
+    "topics": [
+      "web",
+      "browser",
+      "operating-system"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "java",
+      "c++",
+      "git"
+    ],
+    "contact_email": "",
+    "projects_url": "https://docs.google.com/presentation/d/1ozDiULkf2Gi4HH1XA_Ad9O7rQpP9SP0yPEs_dpcBZKM/edit?usp=sharing"
+  },
+  {
+    "name": "CircuitVerse.org",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/circuitverseorg/rxan5pn96f3m4yfu-360.png",
+    "image_background_color": null,
+    "description": "CircuitVerse is an easy to use digital logic circuit simulator which aims at providing a platform to create, share and learn digital circuits. It can run on almost any device without the need for installing any software. The platform has been designed for use by students, professionals and hobbyists alike. The vision is to develop a community around the platform that will aid students to self-learn digital logic design. The platform is currently used by several universities worldwide. Apart from the simulator, users can create, learn, collaborate and share their work. Teachers can create groups and host assignments on the platform. The platform’s impact has been more evident than ever in the Covid 19 pandemic as CircuitVerse enabled schools and colleges to move their courses online.",
+    "url": "http://circuitverse.org/",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "education",
+      "web",
+      "simulation",
+      "pedagogy",
+      "digital logic design"
+    ],
+    "technologies": [
+      "javascript",
+      "ruby",
+      "rails",
+      "canvas",
+      "vue"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/CircuitVerse/CircuitVerse/wiki/GSoC'26-Project-List"
+  },
+  {
+    "name": "CloudCV",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/cloudcv/mxq9gvskhg4i5lyw-360.png",
+    "image_background_color": null,
+    "description": "CloudCV is a young open source cloud platform started in 2013 by students and faculty from Machine Learning and Perception Lab at Virginia Tech (now at Georgia Tech) with the aim to make AI research more reproducible. At CloudCV, we are building tools that enable researchers to build, compare and share state-of-the-art algorithms. We believe that one shouldn't have to be an AI expert to have access to cutting edge vision algorithms. Likewise, researchers shouldn't have to worry about building a service around their deep learning models to showcase and share it with others.",
+    "url": "https://eval.ai/",
+    "category": "Web, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "artificial intelligence",
+      "computer vision",
+      "deep learning",
+      "AI/ML"
+    ],
+    "technologies": [
+      "python",
+      "django",
+      "docker",
+      "angularjs",
+      "aws"
+    ],
+    "contact_email": "",
+    "projects_url": "https://gsoc.cloudcv.org/"
+  },
+  {
+    "name": "CNCF",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/cncf/jmxijrttlucfutel-360.png",
+    "image_background_color": null,
+    "description": "Cloud Native Computing Foundation (CNCF) serves as the vendor-neutral home for many of the fastest-growing open source projects, including Kubernetes, Prometheus, and Envoy.",
+    "url": "https://cncf.io",
+    "category": "Data, Infrastructure and cloud",
+    "topics": [
+      "cloud",
+      "cloud native",
+      "observability"
+    ],
+    "technologies": [
+      "prometheus",
+      "kubernetes",
+      "OpenTelemetry",
+      "envoy"
+    ],
+    "contact_email": "soc@cncf.io",
+    "projects_url": "https://github.com/cncf/mentoring/blob/main/programs/summerofcode/2026.md"
+  },
+  {
+    "name": "CRIU",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/criu/ypjxpancpwtdf698-360.png",
+    "image_background_color": null,
+    "description": "CRIU (stands for Checkpoint/Restore In Userspace), is a Linux software. It can freeze a running container (or an individual application) and checkpoint its state to disk. The data saved can be used to restore the application and run it exactly as it was during the time of the freeze. Using this functionality, application or container live migration, snapshots, remote debugging, and many other things are now possible. \nCRIU is packaged for all leading Linux distributions and it is integrated wit lots of popular projects such as Docker, Podman, LXC/LXD, OpenVZ,  runc,  open-mpi and others",
+    "url": "https://criu.org",
+    "category": "Operating systems, Infrastructure and cloud",
+    "topics": [
+      "cloud",
+      "containers",
+      "Checkpoint/Restore"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "linux",
+      "go"
+    ],
+    "contact_email": "",
+    "projects_url": "https://criu.org/Google_Summer_of_Code_Ideas"
+  },
+  {
+    "name": "D Language Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/d-language-foundation/u25qvh5ljfkkhkjj.png",
+    "image_background_color": null,
+    "description": "The D Language Foundation manages the D programming language and its entire ecosystem.",
+    "url": "https://dlang.org/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "operating systems",
+      "programming languages",
+      "algorithms",
+      "data structures",
+      "optimizations"
+    ],
+    "technologies": [
+      "linux",
+      "make",
+      "d",
+      "windows",
+      "C\\C++"
+    ],
+    "contact_email": "razvan.nitu@dlang.org",
+    "projects_url": "https://dlang.github.io/GSoC/gsoc-2026/project-ideas.html"
+  },
+  {
+    "name": "Dart",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/dart/hsghljw4m6popf0x-360.png",
+    "image_background_color": null,
+    "description": "The Dart language gives you a fast developer experience and works on any platform. Dart powers hot reload enabling you to make a code change and instantly see results in your running app, and compiles to ARM and x64 machine code enabling quick app startup times for mobile, desktop and the web.\n\nDart powers Flutter, Google’s UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.",
+    "url": "https://dart.dev",
+    "category": "Programming languages",
+    "topics": [
+      "programming languages",
+      "mobile apps"
+    ],
+    "technologies": [
+      "flutter",
+      "dart"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/dart-lang/sdk/blob/main/docs/gsoc/Dart-GSoC-2026-Project-Ideas.md"
+  },
+  {
+    "name": "Data for the Common Good",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/data-for-the-common-good/tk4snywy4ejlztpt-360.png",
+    "image_background_color": null,
+    "description": "Data for the Common Good is dedicated to building communities, platforms, and ecosystems that maximize the potential of data to drive discovery and improve human health. Headquartered in the Department of Pediatrics at the University of Chicago, our team of experts works with collaborators all over the world to connect and share useful, high-quality data between institutions, groups, and countries to increase opportunities for discovery.",
+    "url": "https://commons.cri.uchicago.edu",
+    "category": "Web, Infrastructure and cloud",
+    "topics": [
+      "web",
+      "health",
+      "data",
+      "infrastructure",
+      "software"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "kubernetes",
+      "reactjs",
+      "terraform"
+    ],
+    "contact_email": "lgraglia@uchicago.edu",
+    "projects_url": "https://chicagopcdc.github.io/GSoC/ideas"
+  },
+  {
+    "name": "DBpedia",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/dbpedia/cgjegpmawtu5fr6w-360.png",
+    "image_background_color": null,
+    "description": "DBpedia is a crowd-sourced community effort to extract structured information from Wikipedia and make this information available on the Web. It allows for a global and unified access to Knowledge Graphs.",
+    "url": "https://www.dbpedia.org/",
+    "category": "Data, Web",
+    "topics": [
+      "machine learning",
+      "semantic web",
+      "linked data",
+      "knowledge graph",
+      "largelanguagemodel"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "java",
+      "scala",
+      "rdf"
+    ],
+    "contact_email": "dbpedia@infai.org",
+    "projects_url": "https://forum.dbpedia.org/tag/gsoc2026-ideas"
+  },
+  {
+    "name": "Debian",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/debian/mmld9soj4mti8bjn-360.png",
+    "image_background_color": null,
+    "description": "The Debian Project is an association of Free Software developers who\nvolunteer their time and effort in order to produce and maintain a completely free\noperating system Debian. Since its launch, the Debian project has grown to comprise more than 1,000 members with official developer status, alongside many more volunteers and contributors. Today, Debian encompasses over 50,000 packages of free, open source applications and documentation.",
+    "url": "https://debian.org",
+    "category": "Operating systems, End user applications",
+    "topics": [
+      "ai",
+      "CI/CD",
+      "autopkgtest",
+      "raspberrypi_builds",
+      "mobian"
+    ],
+    "technologies": [
+      "python",
+      "java",
+      "perl",
+      "c++",
+      "rust"
+    ],
+    "contact_email": "outreach@debian.org",
+    "projects_url": "https://wiki.debian.org/SummerOfCode2026/Projects"
+  },
+  {
+    "name": "DeepChem",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/deepchem/ffdofoxp3ba1qqmh-360.png",
+    "image_background_color": null,
+    "description": "We democratize access to AI tools for drug discovery and other scientific applications of deep learning more broadly. We also maintain a collection of scientific datasets for benchmarking and building new deep learning architectures along with an extensive open source collection of scientific machine learning tutorials. DeepChem has a strong educational component and partners with a broad range of academic and governmental institutions.",
+    "url": "https://www.deepchem.io",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "artificial intelligence",
+      "chemistry",
+      "biology",
+      "materials science",
+      "Drug Discovery"
+    ],
+    "technologies": [
+      "python",
+      "numpy",
+      "pytorch",
+      "HuggingFace"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/deepchem/deepchem/discussions/4703"
+  },
+  {
+    "name": "Department of Biomedical Informatics, Emory University",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/department-of-biomedical-informatics-emory-university/l9jrm7pdhwnkxh3b-360.png",
+    "image_background_color": null,
+    "description": "Biomedical Informatics is a multidisciplinary field that is motivated by our desire to improve diagnosis, clinical care, and human health, through novel computational approaches to use (and learn from) biomedical and clinical data. We use our expertise in computer science and informatics by developing various enabling tools, technologies, and algorithms to solve specific biomedical and clinical applications. And in doing so help advance our understanding of disease and treatment, and also develop useful software and applications. Members of the department work in a variety of areas that range from machine learning, healthcare middleware that leverages cloud computing, clinical information systems, clinically oriented image analysis, and biomedical knowledge modeling. The driving applications for the various ongoing projects include cancer research, organ transplant, HIV, medical imaging, radiation therapy, and clinical data analytics. All development work that is undertaken is free and open-source.\nWe have had a diverse set of successful GSoC projects in the past. In previous years, GSoC contributors have worked on diverse projects such as: geospatial systems for exploring microscopy environments that leveraged Hadoop; GPU accelerated pipelines for computational analysis of digitized biopsies; interactive visualization platforms for viewing massive images (>1GB); systems for data agnostic sharing of biomedical research datasets; Apache Drill based data integration and de-duplication platform for SQL and NoSQL databases; CNN based high throughput analysis of digitized biopsies; A GUI for Tensorflow; integrated architectures for biomedical data integration and federation; and information visualization of heterogeneous medical data. Many of these projects have been published in reputable journals and presented at major conferences. Some of the projects proved to be so successful that they were adopted in major national/international biomedical research initiatives.",
+    "url": "https://med.emory.edu/departments/biomedical-informatics/",
+    "category": "Security, Artificial Intelligence",
+    "topics": [
+      "cloud",
+      "data integration",
+      "workflows",
+      "data security",
+      "ML/AL"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "java",
+      "bash",
+      "Colab"
+    ],
+    "contact_email": "mzeydab@emory.edu",
+    "projects_url": "https://github.com/NISYSLAB/Emory-BMI-GSoC/?tab=readme-ov-file#list-of-ideas"
+  },
+  {
+    "name": "Django Software Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/django-software-foundation-8o/685unxpkksrvfugu-360.png",
+    "image_background_color": null,
+    "description": "Django is a high-level Python Web framework originally developed at the Lawrence-Journal World. Django was designed to handle two challenges: the intensive deadlines of a newsroom and the stringent requirements of the experienced Web developers who wrote it. It lets you build high-performing, elegant Web applications quickly.",
+    "url": "https://www.djangoproject.com",
+    "category": "Web",
+    "topics": [
+      "web",
+      "python"
+    ],
+    "technologies": [
+      "python",
+      "django"
+    ],
+    "contact_email": "",
+    "projects_url": "https://code.djangoproject.com/wiki/SummerOfCode2026"
+  },
+  {
+    "name": "dora-rs",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/dora-rs-tb/u8emntrmqq6vgcih-360.png",
+    "image_background_color": null,
+    "description": "DORA (Dataflow-Oriented Robotic Architecture) is middleware designed to streamline and simplify the creation of AI-based robotic applications. It offers low latency, composable, and distributed dataflow capabilities. Applications are modeled as directed graphs, also referred to as pipelines.",
+    "url": "https://dora-rs.ai",
+    "category": "End user applications, Programming languages",
+    "topics": [
+      "middleware",
+      "Embodied AI",
+      "Python Robotics",
+      "Autonomous Drive",
+      "Robot Dataflow"
+    ],
+    "technologies": [
+      "python",
+      "ros",
+      "c++",
+      "rust"
+    ],
+    "contact_email": "bding@dora-rs.org",
+    "projects_url": "https://github.com/dora-rs/dora/wiki/GSoC_2026"
+  },
+  {
+    "name": "Drupal Association",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/drupal-association/kfbn4ws0uftixkho-360.png",
+    "image_background_color": null,
+    "description": "Drupal is a powerful Content Management System (CMS) and framework built on PHP, used globally by governments, universities, and businesses to build complex websites and applications, offering unmatched flexibility, security, and scalability through its modular architecture (modules and themes) and community-driven development.",
+    "url": "https://drupal.org",
+    "category": "Web, Social and communication",
+    "topics": [
+      "web",
+      "cloud",
+      "DXP",
+      "Massive community",
+      "Inclusive"
+    ],
+    "technologies": [
+      "mysql",
+      "javascript",
+      "html",
+      "php",
+      "symfony"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.drupal.org/project/issues/gsoc?text=2026&status=All&priorities=All&categories=All&version=All&component=All"
+  },
+  {
+    "name": "Eclipse Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/eclipse-foundation/xo1ntao7atq7yjg2-360.png",
+    "image_background_color": null,
+    "description": "The Eclipse Foundation provides our global community of individuals & organizations with a mature, scalable, and business-friendly environment for OSS collaboration and innovation.\n\nEclipse is an open source community that's focused around key principles of transparency, openness, and vendor neutrality: the work that we do is done in a manner that can be observed by anybody with an interest; project teams welcome new ideas, and invites others to participate;  and vendor neutrality ensures that no single vendor can dominate a project and that everybody plays by the same set of rules (a so-called \"level playing field\").\n\nNaturally, Eclipse projects are also all about the code. With over three hundred and\nsixty (https://projects.eclipse.org/) open source projects covering a diverse set of of\ntechnologies, there's something here for everybody. \n\nEclipse projects build technology in areas such as Internet of Things (https://projects.eclipse.org/technology-type/internet-things), Programming Languages and IDE (https://projects.eclipse.org/technology-type/language), and\nRuntimes (https://projects.eclipse.org/technology-type/runtime) like Jetty and\nEE4J (http://www.eclipse.org/ee4j) (currently known as Java EE).\n\nFor those students interested in research, we have an entire working group focused\non Science (https://projects.eclipse.org/projects/science) where researches from\nsome of the world's most prestigious labs do open source development to support\ntheir research areas.",
+    "url": "https://www.eclipse.org/",
+    "category": "Programming languages, Infrastructure and cloud",
+    "topics": [
+      "robotics",
+      "automotive",
+      "tools",
+      "cloud native java",
+      "iot & edge"
+    ],
+    "technologies": [
+      "java",
+      "rtos",
+      "eclipsejavaide",
+      "jakartaee",
+      "softwaredefinedvehicles"
+    ],
+    "contact_email": "emo@eclipse-foundation.org",
+    "projects_url": "https://gitlab.eclipse.org/eclipsefdn/emo-team/gsoc-at-the-ef/-/issues/?sort=created_date&state=opened&label_name%5B%5D=GSoC%202026&first_page_size=100"
+  },
+  {
+    "name": "Electron",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/electron/vchyhnp6rhabucgj-360.png",
+    "image_background_color": null,
+    "description": "Electron is a framework for building desktop applications using JavaScript, HTML, and CSS. By embedding Chromium and Node.js into its binary, Electron allows you to maintain one JavaScript codebase and create cross-platform apps that work on Windows, macOS, and Linux — no native development experience required.",
+    "url": "https://electronjs.org",
+    "category": "End user applications, Web",
+    "topics": [
+      "desktop",
+      "framework",
+      "javascript"
+    ],
+    "technologies": [
+      "javascript",
+      "node.js",
+      "c++",
+      "typescript",
+      "Chromium"
+    ],
+    "contact_email": "summer-of-code@electronjs.org",
+    "projects_url": "https://electronhq.notion.site/Electron-Google-Summer-of-Code-2025-Ideas-List-1851459d1bd1811894dad8b48a68596d"
+  },
+  {
+    "name": "Fedora Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/fedora-project/shb5orpvxtdcerqq-360.png",
+    "image_background_color": null,
+    "description": "The Fedora Project is a community of people working together to build a free and open source software platform and to collaborate on and share user-focused solutions built on that platform. Or, in plain English, we make an operating system and we make it easy for you to do useful stuff with it.",
+    "url": "https://getfedora.org/",
+    "category": "Operating systems, Programming languages",
+    "topics": [
+      "platform",
+      "ai",
+      "operating system",
+      "LLM",
+      "NetworkManager"
+    ],
+    "technologies": [
+      "python",
+      "bash",
+      "rpm",
+      "security",
+      "Container"
+    ],
+    "contact_email": "",
+    "projects_url": "https://docs.fedoraproject.org/en-US/mentored-projects/gsoc/2025/ideas/"
+  },
+  {
+    "name": "FFmpeg",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/ffmpeg/9nltyc13lvn7dqn0-360.png",
+    "image_background_color": null,
+    "description": "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft.",
+    "url": "https://ffmpeg.org/",
+    "category": "Media",
+    "topics": [
+      "audio",
+      "video",
+      "subtitles",
+      "multimedia"
+    ],
+    "technologies": [
+      "c",
+      "git",
+      "asm"
+    ],
+    "contact_email": "",
+    "projects_url": "https://trac.ffmpeg.org/wiki/SponsoringPrograms/GSoC/2026"
+  },
+  {
+    "name": "FLARE",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/flare/6so0wjs76qeewe9v-360.png",
+    "image_background_color": null,
+    "description": "The Mandiant FLARE team is a collection of about 40 reverse engineers that analyze malware in support of threat intel, incident response, and computer forensic investigations. We spend our days using disassemblers, debuggers, decompilers, and emulators to figure out what malware does and how we can contain it. We’re known for delivering training sessions that share our experience and releasing open source software that automates the boring things. If you have even a passing interest in reverse engineering or malware analysis, reach out so that we can chat!",
+    "url": "https://cloud.google.com/security/flare",
+    "category": "Security, Artificial Intelligence",
+    "topics": [
+      "emulation",
+      "disassembly",
+      "decompilation",
+      "malware-analysis",
+      "reverse-engineering"
+    ],
+    "technologies": [
+      "python",
+      "Sandbox",
+      "ida-pro"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/mandiant/flare-gsoc/blob/2026/doc/project-ideas.md"
+  },
+  {
+    "name": "Fortran-lang",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/fortran-lang/ay9se7mc6vgdwgbn-360.png",
+    "image_background_color": null,
+    "description": "Fortran-lang is an open-source community that develops tools and libraries for modern Fortran development. Our flagship projects include the standard library, Fortran build system and package manager, as well as the interactive compiler, LFortran. Fortran-lang also provides an inclusive and welcoming space for all Fortran enthusiasts around the world to collaborate.",
+    "url": "https://fortran-lang.org",
+    "category": "Programming languages",
+    "topics": [
+      "compilers",
+      "programming languages",
+      "build systems",
+      "libraries",
+      "Fortran"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "fortran"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/fortran-lang/webpage/wiki/GSoC-2026-Project-ideas"
+  },
+  {
+    "name": "FOSSASIA",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/fossasia-bg/rquaoyo4v86xj21l-360.png",
+    "image_background_color": null,
+    "description": "FOSSASIA is an organization developing Open Source software applications and Open Hardware together with a global community from its base in Asia. It is our goal to provide access to open technologies, science applications and knowledge that improve people's lives. We want to enable people to adapt and change technology according to their own ideas and needs and validate science and knowledge through an Open Access approach. FOSSASIA was established 2009 by Hong Phuc Dang and Mario Behling. We organize and participate in conferences, meetups and code camps. The annual FOSSASIA Summit is one of the top tech events in Asia. Other summits take place in Vietnam, Cambodia, Thailand and India. FOSSASIA also runs a number of coding programs such as Codeheat. Please join us and start contributing to our projects, participate as a coder, designer, hardware developer or event organizer.",
+    "url": "https://fossasia.org",
+    "category": "End user applications, Artificial Intelligence",
+    "topics": [
+      "web",
+      "hardware",
+      "event solutions",
+      "android",
+      "firmware"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "javascript",
+      "django",
+      "android"
+    ],
+    "contact_email": "office@fossasia.org",
+    "projects_url": "https://docs.google.com/document/d/1Tz1KxYefreKzBr98C4vbCv9UwnchZoyTwO8rBrz_lmg/edit?tab=t.0#heading=h.9sjk3ie7l2o2"
+  },
+  {
+    "name": "FOSSology",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/fossology/bqfblnvpsqnfg5bh-360.png",
+    "image_background_color": null,
+    "description": "FOSSology is an open source license compliance software system and toolkit. As a toolkit you can run license, copyright and export control scans from the command line. As a system, a database and web UI are provided to give you a compliance workflow. License, copyright and export scanners are tools used in the workflow.",
+    "url": "https://fossology.org",
+    "category": "Web, Security",
+    "topics": [
+      "automation",
+      "spdx",
+      "license compliance",
+      "nlp",
+      "compliance automation"
+    ],
+    "technologies": [
+      "python",
+      "postgresql",
+      "c/c++",
+      "go",
+      "php"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/fossology/fossology/discussions/3267"
+  },
+  {
+    "name": "Free and Open Source Silicon Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/free-and-open-source-silicon-foundation/aie951otsp3xucok.png",
+    "image_background_color": null,
+    "description": "The FOSSi (Free and Open Source Silicon) Foundation is a not-for-profit organization with the support the growing community of open source silicon hardware. We do this with a variety of activities and through Google Summer of Code we bring together enthusiastic mentees and outstanding projects. Under our umbrella are open source silicon hardware projects, operating systems and compilers for such projects, tools for electronic design automation and the related ecosystem.",
+    "url": "https://www.fossi-foundation.org",
+    "category": "Other, Infrastructure and cloud",
+    "topics": [
+      "hardware",
+      "debug",
+      "simulation",
+      "electronic design tools"
+    ],
+    "technologies": [
+      "verilog",
+      "vhdl",
+      "risc-v",
+      "compiler"
+    ],
+    "contact_email": "gsoc@fossi-foundation.org",
+    "projects_url": "https://fossi-foundation.org/gsoc/gsoc26-ideas"
+  },
+  {
+    "name": "FreeCAD",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/freecad/hka287elz3d4wvzu.png",
+    "image_background_color": null,
+    "description": "FreeCAD is a general-purpose parametric 3D computer-aided design (CAD) modeler and a building information modeling (BIM) software application with finite element method (FEM) support. It is intended for mechanical engineering product design but also expands to a wider range of uses around engineering, such as architecture or electrical engineering. FreeCAD is free and open-source, under the LGPL-2.0-or-later license, and available for Linux, macOS, and Windows operating systems. Users can extend the functionality of the software using the Python programming language.",
+    "url": "https://freecad.org",
+    "category": "End user applications, Media",
+    "topics": [
+      "engineering",
+      "graphics",
+      "cad",
+      "3d",
+      "architecture",
+      "BIM",
+      "CAM"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "qt",
+      "OpenCASCADE",
+      "OpenInventor"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.freecad.org/Google_Summer_of_Code_2026"
+  },
+  {
+    "name": "freifunk",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/freifunk/bpcbaeecusvfzbzk-360.png",
+    "image_background_color": null,
+    "description": "We unite wireless communities accross Europe like Freifunk, Ninux, qaul.net, Guifi.net, and Evernet e.G. Our communities either build decentralized wireless networks based on embedded networking hardware or extensively rely on FOSS components such as OpenWRT Linux, OLSR, BATMAN, Babel mesh routing daemons, libremesh, or retroshare applications. The contributions are made by individuals as well as local groups which are highly motivated to build open and free wireless networks providing Internet access to everybody. Moreover, we also create solutions that allow anonymous and secure communication.\n\nThe majority of our networks devices are based on affordable, off-the-shelf WiFi home routers. The Freifunk operating system extends the OpenWrt Linux OS by new kernel and driver features, additional software packages that enable for instance multi-hop wireless mesh networking and new P2P communication features.",
+    "url": "https://freifunk.net/en",
+    "category": "Operating systems, Infrastructure and cloud",
+    "topics": [
+      "security",
+      "embedded systems",
+      "routing",
+      "wireless networks",
+      "federation"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "javascript",
+      "rust",
+      "openwrt"
+    ],
+    "contact_email": "gsoc-org-admins@freifunk.net",
+    "projects_url": "https://projects.freifunk.net"
+  },
+  {
+    "name": "GeomScale",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/geomscale/ongpste986nd7t6p-360.png",
+    "image_background_color": null,
+    "description": "GeomScale is a research and development project that delivers open source code for state-of-the-art algorithms for problems at the intersection of data science, optimization, geometric, and statistical computing. The current focus of GeomScale is on scalable algorithms for sampling from high-dimensional distributions, integration, convex optimization, and their applications. One of our ambitions is to fill the gap between theory and practice by turning state-of-the-art theoretical tools in geometry and optimization to state-of-the-art implementations. Towards this goal, we will deliver various innovative solutions in a variety of application fields, like finance, computational biology, and statistics that will extend the limits of contemporary computational tools. GeomScale aims in serving as a building block for an international, interdisciplinary, and open community in high dimensional geometrical and statistical computing. The main development is currently performed in volesti, a generic open source C++ library, with R and python interfaces (the latter is hosted in package dingo), for high-dimensional sampling, volume approximation, and copula estimation for financial modelling. In particular, the current implementation scales up to hundred or thousand dimensions, depending on the problem. To our knowledge it is the most efficient software package for sampling and volume computation to date. It is, in several cases, orders of magnitude faster compared to packages that solve the same problems. It can be used to compute challenging multivariate integrals and to approximate optimal solutions in optimization problems. It has already found important applications in systems biology by analyzing large metabolic networks (e.g., the latest human network) and in FinTech by detecting shock events and by evaluating portfolios performance in stock markets with thousands of assets. Other application areas include AI and in particular approximate weighted model integration. Recent studies has shown a potential application of volesti methods in trustworthy AI, static analysis of programs and differential privacy.",
+    "url": "https://geomscale.github.io",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "mathematics",
+      "data science",
+      "computational biology",
+      "computational geometry",
+      "statistics"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "r",
+      "jupyter",
+      "github-actions"
+    ],
+    "contact_email": "geomscale@gmail.com",
+    "projects_url": "https://github.com/GeomScale/gsoc26/wiki/table-of-proposed-coding-projects"
+  },
+  {
+    "name": "Git",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/git/mbqqznjbaohwgq80-360.png",
+    "image_background_color": null,
+    "description": "Git is the most widely-used revision control system in Open Source. It is a distributed system with an emphasis on speed, data integrity, and support for distributed, non-linear workflows.\n\nMany large and successful projects use Git, including the Linux Kernel, Perl, Eclipse, Gnome, KDE, Qt, Ruby on Rails, Android, PostgreSQL, Debian, and X.org.\n\nThis organization covers projects for Git itself. Other git-based software or services are not covered by this organization.",
+    "url": "https://git-scm.com/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "version control",
+      "dvcs"
+    ],
+    "technologies": [
+      "shell script",
+      "git",
+      "c language"
+    ],
+    "contact_email": "git@vger.kernel.org",
+    "projects_url": "https://git.github.io/SoC-2026-Ideas/"
+  },
+  {
+    "name": "GitLab",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gitlab/mfhpav5dgegzwg8z-360.png",
+    "image_background_color": null,
+    "description": "Join GitLab's vibrant open source community and help shape the future of DevOps! As a leading DevOps platform, we're committed to making software development accessible to everyone. Whether you're an experienced developer or just starting your open source journey, your contributions – from code and documentation to translations and UX improvements – can impact millions of developers worldwide. Our friendly maintainers are always ready to mentor newcomers, and we've marked plenty of beginner-friendly tasks with \"quick-win\" labels. At GitLab, we believe in collaboration, transparency, and continuous improvement, building everything in the open and sharing with our community. Come be part of our mission to make software development better for everyone.\n\nhttps://gitlab.com/gitlab-org/developer-relations/contributor-success/google-summer-of-code-2025#information-for-applying-students",
+    "url": "https://about.gitlab.com/community/",
+    "category": "Infrastructure and cloud, Development tools",
+    "topics": [
+      "cloud",
+      "ai",
+      "devops",
+      "git",
+      "DevSecOps"
+    ],
+    "technologies": [
+      "javascript",
+      "ruby on rails",
+      "go",
+      "ruby",
+      "vue"
+    ],
+    "contact_email": "contributors@gitlab.com",
+    "projects_url": "https://gitlab.com/gitlab-org/developer-relations/contributor-success/google-summer-of-code/-/work_items"
+  },
+  {
+    "name": "GNOME Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gnome-foundation/aqwqx1x6ozjnxsak-360.png",
+    "image_background_color": null,
+    "description": "The GNOME Foundation is a non-profit organization that believes in a world where everyone is empowered by technology they can trust. We do this by building a diverse and sustainable free software personal computing ecosystem.",
+    "url": "https://gnome.org",
+    "category": "Operating systems, Development tools",
+    "topics": [
+      "operating systems",
+      "desktop",
+      "graphics",
+      "open source",
+      "apps"
+    ],
+    "technologies": [
+      "c",
+      "linux",
+      "rust",
+      "gtk",
+      "Flatpak"
+    ],
+    "contact_email": "",
+    "projects_url": "https://gsoc.gnome.org/2026/"
+  },
+  {
+    "name": "GNSS-SDR",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gnss-sdr/vaciksjfho8cec2g-360.png",
+    "image_background_color": null,
+    "description": "GNSS-SDR is an open source Global Navigation Satellite Systems software receiver, written in C++, that is able to work either from raw signal samples stored in a file, or in real-time with a radio-frequency front-end as signal source, and performs all the signal processing until the observable computation and Position-Velocity-Time solution. Its modularity allows users to populate the framework with their own algorithms, allowing to put the focus on the signal processing implementation without worrying about how to embed that algorithm in a whole GNSS receiver. It also makes possible fair performance benchmarks using real GNSS signals, and its open source license allows free downloading, use and code inspection.\nThe proposed software receiver targets multi-constellation/multi-frequency architectures, pursuing the goals of efficiency, modularity, interoperability, and flexibility demanded by user domains that require non-standard features, such as earth observers or geodesists, and allowing applications such as the observation of the ionosphere, GNSS reflectometry, signal quality monitoring, space weather, and high-accuracy positioning based on carrier-phase navigation techniques. In this project, we focus on signal processing, understood as the process between the ADC and the computation of code and phase observables, including the demodulation of the navigation message. We purposely omit data processing, understood as the computation of the navigation solution from the observables and the navigation message, since there are a number of well-established libraries and applications for that (also in the open source side, such as GPSTk or RTKLIB).",
+    "url": "https://gnss-sdr.org/",
+    "category": "Science and medicine, Other",
+    "topics": [
+      "gnss",
+      "geolocation",
+      "navigation",
+      "software defined radio",
+      "communications"
+    ],
+    "technologies": [
+      "c",
+      "c++",
+      "sdr"
+    ],
+    "contact_email": "",
+    "projects_url": "https://gnss-sdr.org/google-summer-code-2025-ideas-list/"
+  },
+  {
+    "name": "GNU Compiler Collection (GCC)",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gnu-compiler-collection-gcc/kpspl59nyj0hoxlr-360.png",
+    "image_background_color": null,
+    "description": "The GNU Compiler Collection (GCC) is an optimizing compiler produced by the GNU Project supporting various programming languages, hardware architectures and operating systems. It includes front-ends for C, C++, D, Objective-C, Fortran, Ada, and Go, as well as libraries for these languages (such as libgcc and libstdc++). Modula-2, Rust, Cobol, and Algol 68 front-ends are under development too.  GCC includes a Static Analyzer, and supports OpenMP, OpenACC with code offloading to Nvidia and AMD GPUs.",
+    "url": "https://gcc.gnu.org/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "compilers",
+      "developer tools",
+      "toolchain",
+      "openmp",
+      "link time optimization"
+    ],
+    "technologies": [
+      "c/c++",
+      "gnu make",
+      "gnu autotools"
+    ],
+    "contact_email": "",
+    "projects_url": "https://gcc.gnu.org/wiki/SummerOfCode"
+  },
+  {
+    "name": "GNU Image Manipulation Program",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gnu-image-manipulation-program/ocldunfrxwufuvdf.png",
+    "image_background_color": null,
+    "description": "GIMP is a cross-platform image editor available for GNU/Linux, macOS, Windows and more operating systems. It is free software, you can change its source code and distribute your changes.\n\nWhether you are a graphic designer, photographer, illustrator, or scientist, GIMP provides you with sophisticated tools to get your job done. You can further enhance your productivity with GIMP thanks to many customization options and 3rd party plugins.",
+    "url": "https://www.gimp.org/",
+    "category": "End user applications, Media",
+    "topics": [
+      "graphics",
+      "design",
+      "photography",
+      "illustration"
+    ],
+    "technologies": [
+      "c",
+      "GEGL"
+    ],
+    "contact_email": "",
+    "projects_url": "https://developer.gimp.org/core/internship/ideas/"
+  },
+  {
+    "name": "GNU Octave",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gnu-octave/0kc85jo6rl3eo2g0-360.png",
+    "image_background_color": null,
+    "description": "GNU Octave is a high-level interpreted language, primarily intended for numerical computations. It provides capabilities for the numerical solution of linear and nonlinear problems and for performing other numerical experiments. It also provides extensive graphics capabilities for data visualization and manipulation. Octave is normally used through its interactive command line interface, but it can also be used to write non-interactive programs. The Octave language is quite similar to Matlab so that most programs are easily portable.\n\nOctave is continually being upgraded. Student projects may also involve developing or upgrading Octave Forge packages, which can be loaded to provide additional specialized functions that supplement those provided in Core Octave.",
+    "url": "https://www.octave.org",
+    "category": "Science and medicine, Programming languages",
+    "topics": [
+      "mathematics",
+      "scientific computing",
+      "numerical computation",
+      "numerical methods",
+      "matlab"
+    ],
+    "technologies": [
+      "c++",
+      "hg"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.octave.org/wiki/index.php?title=Summer_of_Code_-_Getting_Started#Suggested_projects"
+  },
+  {
+    "name": "GNU Radio",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gnu-radio/v1g5y6exzlwgfulv-360.png",
+    "image_background_color": null,
+    "description": "GNU Radio is a free & open-source software development toolkit that provides signal processing blocks to implement software radios. It can be used with readily-available low-cost external RF hardware to create software-defined radios, or without hardware in a simulation-like environment. It is widely used in research, industry, academia, government, and hobbyist environments to support both wireless communications research and real-world radio systems.\n\nIn brief, a software radio is a radio system which performs the required signal processing in software instead of using dedicated integrated circuits in hardware. The benefit is that since software can be easily replaced in the radio system, the same hardware can be used to create many kinds of radios for many different communications standards; thus, one software radio can be used for a variety of applications!\n\nYou can use GNU Radio to write applications to receive and transmit data with radio hardware, or to create entirely simulation-based applications. GNU Radio has filters, channel codes, synchronization elements, equalizers, demodulators, vocoders, decoders, and many other types of blocks which are typically found in signal processing systems. More importantly, it includes a method of connecting these blocks and then manages how data is passed from one block to another. Extending GNU Radio is also quite easy; if you find a specific block that is missing, you can quickly create and add it.\n\nGNU Radio applications can be written in either C++ or Python, while the performance-critical signal processing path is implemented in C++ using processor floating-point extensions where available. This enables the developer to implement real-time, high-throughput radio systems in a simple-to-use, rapid-application-development environment.",
+    "url": "https://www.gnuradio.org",
+    "category": "Science and medicine",
+    "topics": [
+      "real-time",
+      "dsp",
+      "communications engineering",
+      "cybersecurity",
+      "Software-Defined Radio"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "qt",
+      "simd"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.gnuradio.org/index.php/GSoCIdeas"
+  },
+  {
+    "name": "Google DeepMind",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/google-deepmind-sq/cmdhldmexaj4kpms-360.png",
+    "image_background_color": null,
+    "description": "Google DeepMind is a leading AI research organization committed to solving intelligence and using it to advance science and benefit humanity. We develop cutting-edge machine learning models and techniques, pushing the boundaries of AI across various domains. Our open-source projects, such as JAX (for high-performance numerical computing and machine learning) and Gemma (our open family of models), empower the wider research community. We are dedicated to open science, collaboration, and fostering the next generation of AI talent.",
+    "url": "https://github.com/google-deepmind",
+    "category": "Artificial Intelligence",
+    "topics": [
+      "python",
+      "Jax",
+      "AI,",
+      "Gemma"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "typescript",
+      "Jax",
+      "Gemma"
+    ],
+    "contact_email": "webpaige@google.com",
+    "projects_url": "https://goo.gle/deepmind-gsoc-projects-2025"
+  },
+  {
+    "name": "gprMax",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/gprmax/vm8kavyxz3csja8f-360.png",
+    "image_background_color": null,
+    "description": "gprMax is open source software that simulates electromagnetic wave propagation. It uses Yee's algorithm to solve Maxwell’s equations in 3D using the Finite-Difference Time-Domain (FDTD) method.\n\nIt is designed for simulating Ground Penetrating Radar (GPR) and is used to model electromagnetic wave propagation in fields such as engineering, geophysics, archaeology, and medicine. There are a wide range of applications from assessing infrastructure such as bridges and roads, locating buried utilities, mapping glaciers, finding anti-personnel landmines, to detecting tumours in the human body, and exploring the sub-surface of Mars and the Moon.\n\ngprMax is command-line-driven software written in Python with performance-critical parts written in Cython. It does not currently feature a graphical user interface (GUI) which allows it to be very flexible and scriptable software that can run in high-performance computing (HPC) environments, i.e. on supercomputers.\n\ngprMax can be run on either CPU or GPU. The CPU solver has been parallelised using OpenMP which enables it to run on multi-core CPUs. The GPU solver has been developed using the NVIDIA CUDA programming model. gprMax also features a Messaging Passing Interface (MPI) task farm, which can operate with CPU nodes or multiple GPUs.",
+    "url": "https://www.gprmax.com",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "science",
+      "engineering",
+      "geophysics",
+      "electromagnetics",
+      "ground penetrating radar"
+    ],
+    "technologies": [
+      "python",
+      "cuda",
+      "openmp",
+      "mpi",
+      "opencl"
+    ],
+    "contact_email": "info@gprmax.com",
+    "projects_url": "https://github.com/gprMax/GSoC/blob/main/project-ideas-2026.md"
+  },
+  {
+    "name": "GRAME",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/grame/joff5sziiuapvits-360.png",
+    "image_background_color": null,
+    "description": "Faust (Functional Audio Stream) is a functional programming language for sound synthesis and audio processing with a strong focus on the design of synthesizers, musical instruments, audio effects, etc. Faust targets high-performance signal processing applications and audio plug-ins for a variety of platforms and standards.",
+    "url": "https://faust.grame.fr",
+    "category": "Programming languages, Media",
+    "topics": [
+      "audio",
+      "compiler",
+      "digital signal processing",
+      "function programming language"
+    ],
+    "technologies": [
+      "c",
+      "javascript",
+      "c++",
+      "rust",
+      "typescript"
+    ],
+    "contact_email": "research@grame.fr",
+    "projects_url": "https://github.com/grame-cncm/faustideas/blob/master/GSOC.md"
+  },
+  {
+    "name": "Graphite",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/graphite-labs/p5x1ehnbihaxxqoq-360.png",
+    "image_background_color": null,
+    "description": "Graphite is an in-development raster and vector graphics editing suite that's free and open source. It is powered by a node graph compositing engine that fuses layers with nodes, bringing a generative, procedural approach to the workflows of artists, designers, and animators ranging from students and hobbyists to creative professionals and studios.\n\nThe node-based compositing engine is built similar to a game engine. It is both a real time render pipeline and a visual programming language, complete with a custom compiler letting artists export dynamic content to other applications.\n\nOver time, Graphite intends to evolve into the \"everything app\" across every major 2D creative discipline— a versatile creation suite for graphic design, photo manipulation, digital painting, motion graphics, desktop publishing, and generative art (both procedural and AI-powered).\n\nThe five-year-old project is being rapidly developed by a global team of volunteers, composed mostly of students, who are passionate about crafting high-quality code that will transform and democratize the broader 2D creative industry.\n\nThe mission of Graphite strives to unshackle the creativity of every budding artist and seasoned professional by building the best comprehensive art and design tool that's accessible to all. Mission success will come when Graphite is an industry standard. A cohesive product vision and focus on innovation over imitation is the strategy that will make that possible.",
+    "url": "https://graphite.art",
+    "category": "End user applications, Media",
+    "topics": [
+      "compilers",
+      "programming languages",
+      "graphics",
+      "computational geometry",
+      "fonts"
+    ],
+    "technologies": [
+      "rust",
+      "vulkan",
+      "webgpu"
+    ],
+    "contact_email": "",
+    "projects_url": "https://graphite.art/volunteer/guide/student-projects/"
+  },
+  {
+    "name": "Haskell.org",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/haskellorg/ivy7hfguqhoz8onp-360.png",
+    "image_background_color": null,
+    "description": "Haskell is an advanced, general-purpose, purely functional programming language.  It has a strong, static type system with Hindley-Milner type inference.\n\nThe language natively supports lazy evaluation, and lets you track side effects in the type system. This leads to a concise and declarative style of programming, which differs quite a bit from conventional languages. By controlling side effects and working with immutable data, the programmer can avoid whole classes of bugs.\n\nHaskell generally compiles to fast, native code, but it can also be compiled to other targets like JavaScript (through GHCJS) or LLVM.\n\nIn Google Summer of Code, we attempt to improve not only the language, but the whole ecosystem. This includes (aside from the language itself):\n\n- Compilers\n- Commonly used libraries\n- Commonly used applications written in Haskell\n- Profilers, debuggers and other tools\n- Package managers and infrastructure\n\nWe have compiled an ideas list together with long-time Haskell users, compiler contributors and researchers, and as such we believe these are important projects for the industry and academia both.",
+    "url": "https://haskell.org/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "compilers",
+      "programming languages",
+      "functional programming",
+      "programming tools"
+    ],
+    "technologies": [
+      "haskell",
+      "ghc"
+    ],
+    "contact_email": "committee@haskell.org",
+    "projects_url": "https://summer.haskell.org/ideas.html"
+  },
+  {
+    "name": "HumanAI",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/humanai/n5oaqivpu4hu4alm-360.png",
+    "image_background_color": null,
+    "description": "Machine learning and Artificial Intelligence techniques can be broadly applicable and transferable across many domains. The goals of HumanAI projects are to grow the open-source community in machine learning for the domains of the Arts, Social Sciences and Humanities in addressing various important societal challenges and introducing and transferring the knowledge and tools of machine learning across these disciplines.",
+    "url": "http://humanai.foundation",
+    "category": "Media, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "artificial intelligence",
+      "ai",
+      "Arts",
+      "Humanities"
+    ],
+    "technologies": [
+      "python",
+      "machine learning",
+      "c++",
+      "data analysis",
+      "artificial intelligence"
+    ],
+    "contact_email": "",
+    "projects_url": "https://humanai.foundation/activities/gsoc2026.html"
+  },
+  {
+    "name": "INCF",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/incf/gnryoa8kunjogh9a-360.png",
+    "image_background_color": null,
+    "description": "The International Neuroinformatics Coordinating Facility (INCF; www.incf.org) is an international organization launched in 2005, following a proposal from the Global Science Forum of the OECD. \n\nINCF was established to facilitate and promote the sharing of data and computing resources in the international neuroscience community.  A larger objective of INCF is to help develop scalable, portable, and extensible applications that can be used by neuroscience laboratories worldwide. \n\nThe mission of INCF is to make neuroscience FAIR (Findable, Accessible, Interoperable and Reusable) by sharing and integrating neuroscience data and knowledge worldwide. We foster scientific community collaboration to develop standards for data sharing, analysis  modeling and simulation in order to catalyze insights into brain function in health and disease.\n\nINCF activities are open to all who can contribute to neuroinformatics at the international level. We have a global community of neuroscience researchers working on new and improved tools for all of neuroscience – enabling other researchers to make more and faster discoveries, and improving our understanding of the brain.",
+    "url": "https://www.incf.org",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "data visualization",
+      "neuroscience",
+      "brain modelling",
+      "neuroimage processing"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "java",
+      "c++",
+      "gpu"
+    ],
+    "contact_email": "gsoc@incf.org",
+    "projects_url": "https://docs.google.com/document/d/1XkelmTUV8zMtg99GsZhbYvPoyUG5uzEIWji7IXj0M4k/edit?tab=t.0"
+  },
+  {
+    "name": "Inkscape",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/inkscape/qiomrjtmocpmomjf-360.png",
+    "image_background_color": null,
+    "description": "Inkscape is a free and open-source vector graphics editor used to create vector images, primarily in Scalable Vector Graphics (SVG) format",
+    "url": "https://inkscape.org",
+    "category": "End user applications, Media",
+    "topics": [
+      "web",
+      "graphics",
+      "design"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "svg"
+    ],
+    "contact_email": "",
+    "projects_url": "https://gitlab.com/inkscape/inkscape/-/blob/master/doc/gsoc/summerofcode.md"
+  },
+  {
+    "name": "International Catrobat Association",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/international-catrobat-association/dfkxzmsqlkyvwi2o-360.png",
+    "image_background_color": null,
+    "description": "Computational thinking for all with free visual coding apps\nThe Catrobat project develops useful frameworks to create games, animations, or apps easily within a short time. This set of mobile creativity tools for smartphones is inspired by the well-known Scratch framework by the Lifelong Kindergarten Group at the MIT Media Lab. The motivation behind the project is that programming is an important cultural technique on the same level as mathematics and physics, from a practical as well as from a philosophical point of view. Our aim thus is to popularize the skills needed to program from an early age in a fun and engaging way that will facilitate the spread of its adoption among young people all over the world.\n\nOur awarded Android app “Pocket Code” is currently the most famous outcome of the project. Without the need for any further devices, users have the possibility to create their first program directly on their mobile device in just a few steps using visual \"Bricks\". Pocket Code supports all common device sensors, provides special \"Bricks\" for different robotic devices (Lego Mindstorms, Robotix Phiro, etc.) as well as for hardware devices such as the Arduino board or the Raspberry Pi, and of course offers elements of programming languages such as variables, if-statements, concurrency, etc. We also work on \"Pocket Code\" for iOS and on a large number of extensions. That’s why developers of different fields help us to keep our products up-to-date to meet the current needs of our users.\n\nMotivated by prizes (such as the Lovie Award, the Austrian National Innovation Award or the Re-Imagine Education Award) and being featured by different programs (like Google Play for Education or code.org), our team is working on many different subprojects and extensions. Over 870 developers already contributed to our project on different topics such as app development, web technologies, graphics, usability, internationalization, or design.",
+    "url": "https://www.catrobat.org",
+    "category": "Programming languages, Artificial Intelligence",
+    "topics": [
+      "education",
+      "visual programming",
+      "mobile programming",
+      "game engines",
+      "creativity tools"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "swift",
+      "kotlin",
+      "flutter"
+    ],
+    "contact_email": "contact@catrobat.org",
+    "projects_url": "https://developer.catrobat.org/pages/development/google-summer-of-code/2026/"
+  },
+  {
+    "name": "Internet Archive",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/internet-archive/uzbgzbb9tvp81c2i.png",
+    "image_background_color": null,
+    "description": "The Internet Archive is a non-profit digital library.\n\nWe are the home of the Wayback Machine.",
+    "url": "http://archive.org",
+    "category": "Science and medicine, Media",
+    "topics": [
+      "library",
+      "media",
+      "archiving"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "go",
+      "elasticsearch",
+      "hadoop"
+    ],
+    "contact_email": "info@archive.org",
+    "projects_url": "https://docs.google.com/document/d/1EjzrHVapOZuzdI_Qqd_ravaTgiDWnxlMRbjjbzfd_-I/edit?tab=t.0"
+  },
+  {
+    "name": "Internet Health Report",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/internet-health-report/lifcnmh2qkq9cl5o-360.png",
+    "image_background_color": null,
+    "description": "The Internet Health Report monitors the conditions of networks that compose the Internet. It aims to provide network operators, policymakers, and other stakeholders, with a better understanding of the Internet's infrastructure and its evolution.",
+    "url": "https://ihr.iijlab.net",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "networking",
+      "routing",
+      "communication",
+      "internet",
+      "data analytics"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "apache kafka",
+      "VueJS"
+    ],
+    "contact_email": "admin@ihr.live",
+    "projects_url": "https://github.com/InternetHealthReport/gsoc/blob/main/ideas.md"
+  },
+  {
+    "name": "Invesalius",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/invesalius/ktlk8dmldhfmlyb2-360.png",
+    "image_background_color": null,
+    "description": "InVesalius is an Open Source organization that works developing free software for reconstruction of computed tomography and magnetic resonance images. The software is mainly used for rapid prototyping, teaching, forensics, and in the medical field. It is possible to use it on the Microsoft Windows, GNU/Linux and Apple Mac OS X platforms. \n\nInVesalius main software started began their development on 2001 by Centro de Tecnologia da Informação Renato Archer (CTI), in Brazil, later it was released under GNU license and more practitioners joins the organization to improve their development.\n\nAt that time, there was no medical image software in Portuguese that fulfilled the Brazilian hospitals and clinics needs. Therefore, InVesalius came as a proposal of development with the aim to be a medical software image analysis with null acquisition cost, capability of execution on low-cost personal computers and the\ncapability of execution on different operating systems and act as a platform to encourage the use and development of medical images in Brazil.",
+    "url": "https://invesalius.github.io/",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "ehealth",
+      "medical imaging",
+      "3D Reconstruction",
+      "3d printing",
+      "Neuronavigation"
+    ],
+    "technologies": [
+      "python",
+      "cython",
+      "numpy",
+      "dicom",
+      "Vtk"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/invesalius/gsoc/blob/main/gsoc_2026_ideas.md"
+  },
+  {
+    "name": "IOOS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/ioos/oe7caipkhwnizoyr-360.png",
+    "image_background_color": null,
+    "description": "U.S. IOOS is a national and regional partnership working to provide ocean, coastal and Great Lakes observations, data, tools, and forecasts to improve safety, enhance the economy, and protect our environment.  Our primary purpose is to provide free and open data about the state of our oceans and Great Lakes to our users.  These data are fundamental to understanding the health of our marine ecosystems, to monitor the climate signal as captured in oceanographic conditions, and to provide predictions about the future state of our oceans and coasts.",
+    "url": "https://ioos.noaa.gov/",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "open data",
+      "open science",
+      "data management",
+      "Oceanography",
+      "Marine Biodiversity"
+    ],
+    "technologies": [
+      "python",
+      "java",
+      "r",
+      "Zarr",
+      "NetCDF"
+    ],
+    "contact_email": "micah.wengren@noaa.gov",
+    "projects_url": "https://github.com/ioos/gsoc/blob/main/2026/ideas-list.md"
+  },
+  {
+    "name": "JabRef e.V.",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/jabref-ev/ylevworrwqf9bw9g-360.png",
+    "image_background_color": null,
+    "description": "JabRef is one of the most widely used citation and reference management tools. It helps students and researchers to stay on top of their literature by assisting at every step of a research project: collecting and organizing literature sources, discovering the latest research, citing references in LaTeX and other text editors, and sharing interesting papers with collaborators.\n\nJabRef is open-source and cross-platform. It is written in Java using JavaFX as the user interface technology. It is licensed under the MIT license.\n\nSince 2020 JabRef is maintained by the non-profit organization JabRef e.V.",
+    "url": "https://www.jabref.org/",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "science",
+      "library",
+      "literature",
+      "latex",
+      "bibliography"
+    ],
+    "technologies": [
+      "java",
+      "javafx",
+      "ai",
+      "bibtex"
+    ],
+    "contact_email": "",
+    "projects_url": "https://jabref.github.io/GSoC/projects/"
+  },
+  {
+    "name": "JAX and Keras",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/jax-and-keras/7czut6i8nmxbyzkp-360.png",
+    "image_background_color": null,
+    "description": "This organization has projects for JAX and Keras, two great machine learning libraries.\n\nJAX is a Python library built for high-performance machine-learning research that leverages the familiarity of NumPy with the power of hardware acceleration on CPUs, GPUs, and TPUs.\n\nKeras is a user-friendly and powerful deep learning API written in Python and capable of running on top of either JAX, TensorFlow, or PyTorch",
+    "url": "https://docs.jax.dev/",
+    "category": "Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "Jax",
+      "keras",
+      "PYTHON LIBRARY"
+    ],
+    "technologies": [
+      "python",
+      "machine learning",
+      "ai"
+    ],
+    "contact_email": "",
+    "projects_url": "https://docs.google.com/document/d/16uAZEldrXUBHjrszSO22Hr81OmVSjzVXza0szZl6Fxw/edit?usp=sharing"
+  },
+  {
+    "name": "JdeRobot",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/jderobot/xwu8zkcagffmlqdj-360.png",
+    "image_background_color": null,
+    "description": "Robotics applications are typically distributed, made up of a collection of concurrent asynchronous components which communicate using some middleware (ROS messages, DDS...). Building robotics applications is a complex task. Integrating existing nodes or libraries that provide already solved functionality, and using several tools may increase the software robustness and shorten the development time. JdeRobot provides several tools, libraries and reusable nodes. They have been written in C++, Python or JavaScript.\n\nOur community mainly works on four development areas:\n1.- Education in Robotics\n* RoboticsAcademy (https://jderobot.github.io/RoboticsAcademy/): a ROS-based framework to learn robotics and computer vision with drones, autonomous cars.... It is a collection of Python programmed exercises for engineering students. \n* Unibotics: a web based framework for teaching robotics.\n\n2.- Robot Programming Tools\t\n* VisualCircuit (https://jderobot.github.io/VisualCircuit/) for robot programming with connected blocks, as in electronic circuits, in a visual way\n* VisualStates for robot programming with Finite State Machines in a visual way\n* WebSim2D robot simulator with web technologies\n\n3.- MachineLearning in Robotics\n* DeepLearningSuite: neural networks for robot control. It includes the BehaviorMetrics tool for assessment of neural networks for autonomous driving\n* RL-Studio: Robotic library for the training of Reinforcement Learning algorithms\n* DetectionMetrics tool for evaluation of visual detection neural networks and algorithms\n\n4.- FPGAs in Robotics\n* FPGA-robotics (https://github.com/JdeRobot/FPGA-robotics): programming robots with reconfigurable computing (FPGAs) using open tools as IceStudio and Symbiflow. Verilog-based reusable blocks for robotics applications.\n* NeuralFPGA: running deeplearning networks on FPGAs",
+    "url": "http://jderobot.github.io",
+    "category": "Other, Artificial Intelligence",
+    "topics": [
+      "education",
+      "artificial intelligence",
+      "robotics",
+      "computer vision",
+      "developer tools"
+    ],
+    "technologies": [
+      "python",
+      "ros",
+      "gazebo",
+      "opencv",
+      "tensorflow"
+    ],
+    "contact_email": "jderobot@gmail.com",
+    "projects_url": "https://jderobot.github.io/activities/gsoc/2026#ideas-list"
+  },
+  {
+    "name": "Jenkins",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/jenkins-wp/7qlgfron9nyj194y-360.png",
+    "image_background_color": null,
+    "description": "Short description:\n\nJenkins is a popular open source automation server which is used for building, testing, CI/CD, deployment and many other use-cases. Our motto is \"Build great things at any scale\".\n\nLong description:\n\nJenkins, originally founded in 2006 as \"Hudson\", is one of the leading automation servers. Jenkins' motto is \"Build great things at any scale\". Using an extensible, plugin-based architecture, developers have created hundreds of plugins to adapt Jenkins to a multitude of build, test, and deployment automation workloads. As Jenkins is open-source, MIT License is used for most of the components.\n\nThis year we invite potential GSoC contributors to join the Jenkins community and to work together to improve Jenkins. We have many strategic project ideas which are important to potentially hundreds of thousands of Jenkins users.\n\nThe project has over 600 active contributors working on Jenkins core, plugins, website, project infrastructure, localization activities, etc. In total we have more than 2,000 components including plugins, libraries, and various utilities. The main languages in the project are Java, Groovy and JavaScript, but we also have components written in other languages (Go, C/C++, C#, etc.). Jenkins project includes multiple sub-projects (including Configuration-as-Code, Infrastructure and Remoting) and special interest groups. These entities participate in GSoC as a part of the Jenkins project.\n\nThe Jenkins project is a part of Continuous Delivery Foundation (CDF).",
+    "url": "https://jenkins.io",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "developer tools",
+      "automation",
+      "continuous integration",
+      "continuous delivery",
+      "devops"
+    ],
+    "technologies": [
+      "javascript",
+      "java",
+      "go",
+      "docker",
+      "kubernetes"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.jenkins.io/projects/gsoc/2026/project-ideas/"
+  },
+  {
+    "name": "Jitsi",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/jitsi/p3456ygkk7vdq0or-360.png",
+    "image_background_color": null,
+    "description": "Jitsi is a set of Open Source projects which empower users to deploy secure, scalable and easy to use video conferencing platforms with state-of-the-art video quality and features.",
+    "url": "https://jitsi.org",
+    "category": "Media, Web",
+    "topics": [
+      "video",
+      "multimedia",
+      "video conferencing",
+      "WebRTC"
+    ],
+    "technologies": [
+      "javascript",
+      "java",
+      "react",
+      "kotlin",
+      "webrtc"
+    ],
+    "contact_email": "gsoc@jitsi.org",
+    "projects_url": "https://github.com/jitsi/gsoc-ideas/blob/master/2026/README.md"
+  },
+  {
+    "name": "Joomla!",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/joomla/dwntn9vfd52jkr9z.png",
+    "image_background_color": null,
+    "description": "The Joomla CMS is a PHP based application that powers about 2.2% of the web, 3.5% of all CMS based websites, as well as many intranets. Joomla has been downloaded over 119 Million times: https://downloads.joomla.org/\n\nThe Joomla project has hundreds of contributors, organized in a set of working groups and teams, and a leadership group. These are coordinated by the [Departments](https://volunteers.joomla.org/departments/ \"Joomla Departments\").\n\nJoomla is a community driven FOSS project developed and maintained by an international community encompassing over 150 countries. Joomla is used by millions of websites and web applications ranging from the hobbyist, professional web developer, to large enterprises, for both the World Wide Web and intranets.\n\nJoomla is available in 76 languages with an active and dedicated translation team\nhttps://community.joomla.org/translations/joomla-3-translations.html\n\n\nThe Joomla Project is a community effort which strives to engage contributors from diverse backgrounds and varying interests and skills in building and supporting great software together. The [mission, vision and values](https://www.joomla.org/about-joomla/the-project/mission-vision-and-values.html \"Joomla Mission vision and values\") of the Joomla Project reflect this.\n\nThe official umbrella organisation is Open Source Matters (OSM), the not for profit organization that manages financial and legal issues for the Joomla Project. A team of experienced people drawn from many areas of the project will manage the 2025 GSoC project for Joomla.",
+    "url": "https://www.joomla.org/",
+    "category": "End user applications, Web",
+    "topics": [
+      "web",
+      "programming languages",
+      "web development",
+      "web applications",
+      "cms"
+    ],
+    "technologies": [
+      "mysql",
+      "javascript",
+      "html",
+      "php",
+      "ai"
+    ],
+    "contact_email": "gsoc@joomla.org",
+    "projects_url": "https://community.joomla.org/gsoc/projects-2026.html"
+  },
+  {
+    "name": "JSON Schema",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/json-schema/d3qfjxegxnlrfysi.png",
+    "image_background_color": null,
+    "description": "JSON Schema is a vocabulary that allows you to annotate and validate JSON documents \n\nWe are a community JSON Schema enthusiast dedicated to maintain, evolve and promote the JSON Schema specification. The Community consists of individuals, community members, tooling builders, schema designers, researchers, and representatives from companies and organizations who use or are considering using JSON Schema.",
+    "url": "https://json-schema.org/",
+    "category": "Data, Programming languages",
+    "topics": [
+      "web",
+      "apis",
+      "standards",
+      "data validation",
+      "developer tooling"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "typescript",
+      ".net",
+      "JSON Schema"
+    ],
+    "contact_email": "info@json-schema.org",
+    "projects_url": "https://github.com/json-schema-org/community/blob/main/programs/mentoring/gsoc/gsoc-2026.md"
+  },
+  {
+    "name": "KDE Community",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kde-community/1mbnnsqwd2ejcmy8-360.png",
+    "image_background_color": null,
+    "description": "Community of technologists, designers, writers and advocates who work to ensure freedom for all people through our software.",
+    "url": "https://kde.org/",
+    "category": "End user applications",
+    "topics": [
+      "education",
+      "science",
+      "applications",
+      "desktop environment"
+    ],
+    "technologies": [
+      "c++",
+      "qt",
+      "qml",
+      "data structures"
+    ],
+    "contact_email": "",
+    "projects_url": "https://community.kde.org/GSoC/2026/Ideas"
+  },
+  {
+    "name": "Keploy",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/keploy/txoec8qr8fyegtmv-360.png",
+    "image_background_color": null,
+    "description": "An open-source simple e2e and unit test generation toolkit for developers. Keploy creates test cases, data mocks, stubs from API calls, DB queries, etc. TestGPT that actually works!",
+    "url": "https://keploy.io",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "AI/ML",
+      "API Testing",
+      "Dev Tool",
+      "Functional Testing",
+      "AI Testing Agent"
+    ],
+    "technologies": [
+      "python",
+      "golang",
+      "node",
+      "ai",
+      "MERN"
+    ],
+    "contact_email": "hello@keploy.io",
+    "projects_url": "https://github.com/keploy/gsoc/tree/main/2026"
+  },
+  {
+    "name": "Kiwix",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kiwix/b6zuffwiyoulh0ku-360.png",
+    "image_background_color": null,
+    "description": "Kiwix provides copies of websites that can be browsed offline. We run scrapers that will crawl a given website and compress it into a single .zim archive (based on the openZIM format). <br/><br/>\n\nThe zim files can then be stored locally and read on the fly by Kiwix in such a way that the user experience is similar to being online. <br/><br/>\n\nWe can fit the entirety of Wikipedia on a regular Android phone, but there are more than 7,000 zim files available in 100+ languages, mostly focused on educational content (e.g. Wikipedia, StackOverflow, Khan Academy, etc.).\n\n<br/><br/>\n\nKiwix runs on all platforms (Linux, Windows, Android, etc.) and has around 10-12 million users worldwide, in pretty much any place you can think of that has limited or no connectivity: prisons, rural schools, refugee camps, even Antarctic bases!\n<br/><br/>\nOur big challenge is to make it as easy as possible to access or share offline content.",
+    "url": "https://www.kiwix.org",
+    "category": "End user applications, Other",
+    "topics": [
+      "offline",
+      "browser",
+      "compression"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "nodejs",
+      "kotlin",
+      "vue.js"
+    ],
+    "contact_email": "contact+gsoc@kiwix.org",
+    "projects_url": "https://kiwix.org/en/google-summer-of-code/"
+  },
+  {
+    "name": "Kornia",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kornia/p4e366l478clqvvg-360.png",
+    "image_background_color": null,
+    "description": "Kornia AI is a non-profit organization advancing Spatial Artificial Intelligence through open collaboration. Founded in 2018 and  registered as a non-profit in 2023, Kornia AI is supported by a global contributor community. The organization began with Kornia, a widely adopted Python library for Differentiable Computer Vision (>2M downloads/month, 400+ Google Scholar citations).\n In recent years, the core maintainers have shifted focus to kornia-rs, a native Rust stack for high‑performance 3D computer vision and spatial AI. Our direction emphasizes robotics and edge deployment: safe, memory‑efficient, low‑latency pipelines that run on constrained devices (e.g., embedded/Jetson‑class hardware). kornia-rs is gaining traction in the open-source community and is used by leading companies such as Farm-ng, Rerun.io, and Copper Robotics, who have featured the project on their platforms.",
+    "url": "https://docs.rs/kornia",
+    "category": "Programming languages, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "artificial intelligence",
+      "robotics",
+      "computer vision",
+      "3D Geometry"
+    ],
+    "technologies": [
+      "cuda",
+      "rust",
+      "deep learning",
+      "data science",
+      "Spatial AI"
+    ],
+    "contact_email": "hello@kornia.org",
+    "projects_url": "https://github.com/kornia/kornia-rs/wiki/%5B2026%5D-Google-Sumer-of-Code-Application"
+  },
+  {
+    "name": "Kotlin Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kotlin-foundation/2wyghqyy8nvvl4cq-360.png",
+    "image_background_color": null,
+    "description": "Kotlin is a concise, modern, and versatile programming language designed for multiple platforms.\n\nThe Kotlin Foundation, established by JetBrains and Google, later welcomed Meta, Uber, Gradle, Touchlab, Block, and Kotzilla. Together, we promote and advance Kotlin across multiple platforms, including Android, iOS, web, desktop, and server-side.\n \nCurrently, 100+ engineers from JetBrains and Google contribute to the core Kotlin project, alongside 350+ independent contributors and thousands more supporting the broader Kotlin ecosystem.\n\nThe Kotlin Foundation is committed to protecting, promoting, and advancing the evolution of the Kotlin language.",
+    "url": "https://kotlinfoundation.org/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "compilers",
+      "programming languages",
+      "software development",
+      "libraries",
+      "Programming & Build Tools"
+    ],
+    "technologies": [
+      "kotlin",
+      "jvm",
+      "ai",
+      "Parsers & Compilers",
+      "Multiplatform"
+    ],
+    "contact_email": "gsoc@kotlinfoundation.org",
+    "projects_url": "https://kotlinlang.org/docs/gsoc-2026.html"
+  },
+  {
+    "name": "kro | Kube Resource Orchestrator",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kro-kube-resource-orchestrator/qf9flxp0iswvhnli-360.png",
+    "image_background_color": null,
+    "description": "kro is an open source organization dedicated to simplifying Kubernetes resource management through its flagship project, the Kube Resource Orchestrator (kro). The organization develops and maintains tools that enable platform teams, developers, and DevOps professionals to create and manage complex Kubernetes configurations with ease. By providing a framework that allows teams to define custom APIs using straightforward configuration, kro helps organizations standardize their Kubernetes deployments, enforce security best practices, and streamline collaboration between platform, security, and development teams.",
+    "url": "https://kro.run/",
+    "category": "Infrastructure and cloud, Development tools",
+    "topics": [
+      "automation",
+      "kubernetes",
+      "configuration management",
+      "cloud native"
+    ],
+    "technologies": [
+      "prometheus",
+      "golang",
+      "kubernetes",
+      "controller-runtime",
+      "CEL"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/kro-run/kro/issues/288"
+  },
+  {
+    "name": "Kubeflow",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kubeflow/uqphmd1y7opxpjim-360.png",
+    "image_background_color": null,
+    "description": "Our goal is to streamline the process of scaling and deploying machine learning (ML) models to production by leveraging Kubernetes' strengths: \n<br /><br />\n-   Seamless deployments: Effortless, repeatable, and portable deployments across diverse infrastructure, allowing you to experiment on local machines and then seamlessly transition to on-premises clusters or the cloud.\n<br /><br />\n-   Microservice management: Efficient deployment and management of loosely-coupled microservices for building modular and scalable ML pipelines.\n<br /><br />\n-   Dynamic scaling: Automated scaling based on demand, ensuring optimal resource utilization.\n<br /><br />\nUser-centric design: Recognizing the diverse tool preferences within the ML community, we prioritize user customization (within reasonable boundaries). Our system takes care of the repetitive tasks, freeing users to focus on the core ML challenges.\n<br /><br />\nStarting focused, expanding rapidly: While we initially focused on specific technologies, we actively collaborate with various projects to integrate additional tools and broaden our reach.\n<br /><br />\nOur vision: A future where simple manifests empower you to utilize a user-friendly ML stack anywhere Kubernetes runs, with self-configuration capabilities based on the deployment environment.",
+    "url": "https://kubeflow.org",
+    "category": "Infrastructure and cloud, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "kubernetes",
+      "AI/ML",
+      "generative AI"
+    ],
+    "technologies": [
+      "python",
+      "go",
+      "kubernetes",
+      "typescript",
+      "YAML"
+    ],
+    "contact_email": "https://groups.google.com/g/kubeflow-discuss",
+    "projects_url": "https://www.kubeflow.org/events/upcoming-events/gsoc-2026/"
+  },
+  {
+    "name": "KubeVirt",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/kubevirt/pqdi8ojm0atxoo1s-360.png",
+    "image_background_color": null,
+    "description": "KubeVirt is a virtual machine management extension for Kubenetes, allowing you to create and manage virtualised workloads natively alongside container workloads. It does this by adding virtualization resources through the Kubernetes Custom Resource Definition API.\n\nKubeVirt is a Cloud Native Computing Project (CNCF) incubating project.",
+    "url": "https://kubevirt.io",
+    "category": "Infrastructure and cloud",
+    "topics": [
+      "virtualization",
+      "containers",
+      "kubernetes"
+    ],
+    "technologies": [
+      "golang",
+      "grpc"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/kubevirt/community/wiki/Google-Summer-of-Code-2026"
+  },
+  {
+    "name": "LabLua",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/lablua/thpyrwywpx4z6p6s.png",
+    "image_background_color": null,
+    "description": "LabLua is a research lab at the Catholic University of Rio de Janeiro (PUC-Rio), affiliated with its Computer Science Department. It is dedicated to research on programming languages, with emphasis on the Lua language and reactive programming. It was founded on May 2004 by Prof. Roberto Ierusalimschy, the chief architect of the Lua language.\n\n\nLabLua consists of people from a wide range of backgrounds, including PhD candidates, professors and alumni who are the developers and maintainers of projects that are used by the Lua community at large.\n\n\nWhat is Lua?\n\n\nLua is a powerful, efficient, lightweight, embeddable scripting language. It supports procedural programming, object-oriented programming, functional programming, data-driven programming, and data description.\n\n\nLua has been used in many industrial applications (e.g., Adobe's Photoshop Lightroom), with an emphasis on embedded systems (e.g., the Ginga middleware for digital TV in Brazil) and games (e.g., World of Warcraft and Angry Birds). Several versions of Lua have been released and used in real applications since its creation in 1993.\n\nWhat is Lunatik?\n\nLunatik is an extension framework for Linux that combines the approaches of Extensible Operating Systems and Scripting Languages. This approach, named Kernel Scripting, advocates that OS kernels can be dynamically extended by using a high-level scripting language. Lunatik is a programming and execution environment that offers two main features: it allows developers to make subsystems scriptable and allows users to run Lua scripts in the kernel.\n\nWhat is Pallene?\n\nPallene is a statically-typed programming language, intended to serve as a more performant companion to Lua. It is designed to seamlessly interoperate with Lua, with first-class support for Lua data types. Pallene is able to be faster than Lua (sometimes as fast as LuaJIT) by taking advantage of the type annotations in Pallene in order to guide the compiler into outputting efficient executable code.",
+    "url": "http://www.lua.inf.puc-rio.br",
+    "category": "Operating systems, Programming languages",
+    "topics": [
+      "compilers",
+      "scripting languages",
+      "kernel scripting",
+      "statically-typed languages"
+    ],
+    "technologies": [
+      "lua",
+      "luarocks",
+      "kernel",
+      "lunatik",
+      "pallene"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/labluapucrio/gsoc"
+  },
+  {
+    "name": "Learning Equality",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/learning-equality/iptmmzjiktknrg9p-360.png",
+    "image_background_color": null,
+    "description": "Learning Equality is an education technology nonprofit focused on fostering  student-centered learning and advancing organizations working with underserved teachers and learners globally. Through community-driven innovation and strategic partnerships, we provide offline-first, open-source digital tools and implementation support to help them thrive.\nWe create and support open-source technology that directly and focally addresses the infrastructural and resource equity gaps that further marginalize learners with limited Internet. We started by enabling offline access to Khan Academy's videos and exercises and grew to become a key player in the global education technology landscape. For the past 13 years we’ve focused on boosting learning outcomes in some of the most challenging contexts, supporting disconnected learning in refugee camps, rural schools, out-of-school programs, and more.\nLearning Equality develops and maintains Kolibri, an adaptable set of open tools specially designed to support teaching and learning with tech but without the Internet for the third of the world that still lacks access to connectivity.\nKolibri is centered around an offline-first learning platform that runs on a variety of low-cost and legacy devices. It is complemented by a curricular tool, a library of open educational materials, and a toolkit of resources to support training and implementation. These tools are open and available in a variety of languages to better support learners and educators globally.\nAs a community-driven nonprofit, Learning Equality works closely to co-design Kolibri with a core network of collaborators, including national NGOs, UN agencies, government, and corporate partners. We also adopt a needs-based approach, constantly gathering insights from our community to inform the development of our tools.\nThrough its do-it-yourself adoption model and strategic collaborations, Learning Equality has conservatively reached  13 million  learners and educators in every country in the world. Given our offline access and distribution model, we learn about usage of Kolibri through a combination of telemetry ping backs of high level, aggregate, anonymized statistics, data from partners, and use of our Kolibri Data Portal. Since instances of Kolibri never need to connect to the Internet to be used, we do not know about usage across every instance, which is why this is an informed estimate from years of data.",
+    "url": "https://learningequality.org/",
+    "category": "End user applications, Other",
+    "topics": [
+      "education",
+      "distributed databases",
+      "offline",
+      "learning"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "django",
+      "vue.js"
+    ],
+    "contact_email": "gsoc@learningequality.org",
+    "projects_url": "https://docs.google.com/document/d/e/2PACX-1vShAAywLDbBu5WH-Wv44rxetISCOQmHxBwxDw63Nt_OcpPVIZW2jjT8sd_GLTpeNvspze8W-_c9JUdl/pub"
+  },
+  {
+    "name": "LibreOffice",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/libreoffice/3g60m1gvsyzwzvvk-360.png",
+    "image_background_color": null,
+    "description": "LibreOffice is a modern Free & Open Source Office suite, one of the largest open source projects, and used by millions of users worldwide. LibreOffice is compatible with many file formats like Microsoft® Word, Excel, PowerPoint and Publisher. At its heart though, LibreOffice is built around an open standard, the OpenDocument Format, as its native file format.\nLibreOffice is developed by users who, just like you, believe in the principles of Free Software and in sharing their work with the world in non-restrictive ways. The development of LibreOffice is supported by The Document Foundation which provides the infrastructure for the project.\nWe believe that users should have the freedom to run, copy, distribute, study, change and improve the software that we distribute. While we do offer no-cost downloads of the LibreOffice suite of programs, Free Software is first and foremost a matter of liberty, not price. We campaign for these freedoms because we believe that everyone deserves them.\nThough the members of our community hail from many different backgrounds, we all value personal choice and transparency, which translates practically into wider compatibility, more utility, and no end-user lock-in to a single product. We believe that Free Software can provide better-quality, higher-reliability, increased-security, and greater-flexibility than proprietary alternatives. LibreOffice is a large project (approx. 6MLOC), which makes it interestingly complex, but at the same time, provides a place for all sorts of contribution & skills.\nThe community behind LibreOffice is the heart of the project, without which we would not have the resources to continue developing our software. The passion and drive that every individual brings to the community results in collaborative development that often exceeds our own expectations. With tons of different roles in the project, we invite everyone to join us in our work and help us to make LibreOffice known, prosper, and accessible to all.",
+    "url": "https://www.libreoffice.org/",
+    "category": "End user applications",
+    "topics": [
+      "office suite",
+      "desktop application",
+      "end user application"
+    ],
+    "technologies": [
+      "python",
+      "java",
+      "c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.documentfoundation.org/Development/GSoC/Ideas"
+  },
+  {
+    "name": "libssh",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/libssh/kcfc8lhxh3uyozbu-360.png",
+    "image_background_color": null,
+    "description": "This project is for programmers needing a working SSH implementation by the mean of a library. The complete control of the client is made by the programmer. With libssh, you can remotely execute programs, transfer files, use a secure and transparent tunnel for your remote programs. With its Secure FTP implementation, you can play with remote files easily, without third-party programs others than libcrypto (from openssl), libgcrypt or mbedTLS.",
+    "url": "https://www.libssh.org/",
+    "category": "Programming languages, Security",
+    "topics": [
+      "security",
+      "cryptography"
+    ],
+    "technologies": [
+      "c",
+      "git",
+      "ci",
+      "ssh",
+      "sftp"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.libssh.org/development/google-summer-of-code/"
+  },
+  {
+    "name": "Liquid Galaxy project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/liquid-galaxy-project/idbd8hebl6j7ajxn-360.png",
+    "image_background_color": null,
+    "description": "Liquid Galaxy is a remarkable panoramic system that is tremendously compelling. It started off as a Google 20% project to run Google Earth across a small cluster of PC's and it has grown from there! \nLiquid Galaxy hardware consists of one or more computers driving multiple displays. Liquid Galaxy applications have been developed using a master/slave architecture. The view orientation of each slave display is configured in reference to the view of the master display. Navigation on the system is done from the master instance and the location on the master is broadcast to the slaves over UDP. The slave instances, knowing their own locations in reference to the master, then change their views accordingly.\nThe Liquid Galaxy Project, while making use of Google Earth software, does not develop the Google Earth code-base itself. Google Earth is not open-source software, although it is free (as in beer). Instead, the Liquid Galaxy Project works on extending the Liquid Galaxy system with open-source software both improving its administration and enabling open-source applications, so that content of various types can be displayed in the immersive panoramic environment.\nArtificial Intelligence focus:\n2026 is the year when AI is going to change the coding industry, and GSoC and the open-source projects on it, have to jump on.\nAt the Liquid Galaxy community, we’ve been using AI for years to obtain data to be shown on Google Earth for our projects, using many models and technologies. \nThis 2026, all the projects will have an Artificial Intelligence voice, and most of them will use of diferent AI models to handle queries and arrange data, starting from Google's Gemini and Gemma.",
+    "url": "https://www.liquidgalaxy.eu",
+    "category": "Data",
+    "topics": [
+      "visualization",
+      "artificial intelligence",
+      "networking",
+      "maps",
+      "ux"
+    ],
+    "technologies": [
+      "linux",
+      "android",
+      "nodejs",
+      "flutter",
+      "Google Earth"
+    ],
+    "contact_email": "liquidgalaxylab@gmail.com",
+    "projects_url": "https://www.liquidgalaxy.eu/2026/01/gsoc-2026-project-ideas.html"
+  },
+  {
+    "name": "LLVM Compiler Infrastructure",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/llvm-compiler-infrastructure/ize6lrlftlvdxtqe-360.png",
+    "image_background_color": null,
+    "description": "The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. Despite its name, LLVM has little to do with traditional virtual machines. The name \"LLVM\" itself is not an acronym; it is the full name of the project.\n\nLLVM began as a research project at the University of Illinois, with the goal of providing a modern, SSA-based compilation strategy capable of supporting both static and dynamic compilation of arbitrary programming languages. Since then, LLVM has grown to be an umbrella project consisting of a number of subprojects, many of which are being used in production by a wide variety of commercial and open source projects as well as being widely used in academic research.\n\nIn addition to official subprojects of LLVM, there are a broad variety of other projects that use components of LLVM for various tasks. Through these external projects you can use LLVM to compile Ruby, Python, Haskell, Rust, D, PHP, Pure, Lua, Julia, and a number of other languages. A major strength of LLVM is its versatility, flexibility, and reusability, which is why it is being used for such a wide variety of different tasks: everything from doing light-weight JIT compiles of embedded languages like Lua to compiling Fortran code for massive super computers.",
+    "url": "http://www.llvm.org",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "compilers",
+      "development tools",
+      "libraries"
+    ],
+    "technologies": [
+      "llvm",
+      "c++",
+      "clang",
+      "mlir"
+    ],
+    "contact_email": "",
+    "projects_url": "https://llvm.org/OpenProjects.html"
+  },
+  {
+    "name": "Machine Learning for Science (ML4SCI)",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/machine-learning-for-science-ml4sci/rs5cxhuyh9dpwekt-360.png",
+    "image_background_color": null,
+    "description": "Machine Learning for Science (ML4SCI) is an umbrella organization for machine learning-related projects in science. ML4SCI brings together researchers from universities and scientific laboratories with motivated students to join existing scientific collaborations and contribute to cutting edge science projects across a wide variety of disciplines. Students work on existing problems to develop new machine learning-based approaches and produce open source code that directly contributes to solving these scientific challenges. \n\nML4SCI currently includes projects from a variety of fields. For example, some of them explore the uses of machine learning for particle reconstruction and classification in high-energy physics, deep learning-based searches for dark matter in astrophysics, applications of machine learning techniques to data returned from planetary science missions, applications of quantum machine learning to science, and others.\n\nMachine learning ideas and approaches can be broadly applicable and transferable across the scientific domains. The goals of ML4SCI projects are to grow the open-source community in machine learning for science by addressing important scientific challenges and transferring the knowledge and tools of machine learning across the disciplines. We look forward to your applications!",
+    "url": "https://ml4sci.org/",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "machine learning",
+      "science and medicine",
+      "algorithms",
+      "physics",
+      "astronomy"
+    ],
+    "technologies": [
+      "python",
+      "machine learning",
+      "c++",
+      "data analysis",
+      "artificial intelligence"
+    ],
+    "contact_email": "",
+    "projects_url": "https://ml4sci.org/activities/gsoc2026.html"
+  },
+  {
+    "name": "MariaDB",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/mariadb/0nbzguld3ntsgeqv-360.png",
+    "image_background_color": null,
+    "description": "MariaDB Foundation is the non-profit organization behind MariaDB Server, the fastest growing open source databases. MariaDB Foundation's mission is to ensure the continuity of the MariaDB Server code as well as foster and facilitated collaboration within the MariaDB ecosystem. As part of GSoC, MariaDB Foundation seeks to bring more developers into the MariaDB Server (and related projects) code base.",
+    "url": "https://mariadb.org",
+    "category": "Data",
+    "topics": [
+      "Database Engines",
+      "SQL Features"
+    ],
+    "technologies": [
+      "python",
+      "c/c++",
+      "perl",
+      "databases"
+    ],
+    "contact_email": "",
+    "projects_url": "https://mariadb.com/docs/general-resources/community/contributing-participating/google-summers-of-code/google-summer-of-code-2026"
+  },
+  {
+    "name": "MBDyn",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/mbdyn/ambfdghkrcyizd8l-360.png",
+    "image_background_color": null,
+    "description": "MBDyn is the first free general purpose Multibody Dynamics analysis software. It has been developed at the Dipartimento di Scienze e Tecnologie Aerospaziali (formerly Dipartimento di Ingegneria Aerospaziale) of the University \"Politecnico di Milano\", Italy. MBDyn features the integrated multidisciplinary simulation of multibody, multiphysics systems, including nonlinear mechanics of rigid and flexible bodies (geometrically exact & composite-ready beam and shell finite elements, component mode synthesis elements, lumped elements) subjected to kinematic constraints, along with smart materials, electric networks, active control, hydraulic networks, and essential fixed-wing and rotorcraft aerodynamics. MBDyn simulates the behavior of heterogeneous mechanical, aeroservoelastic systems based on first principles equations. MBDyn can be easily coupled to external solvers for co-simulation of multiphysics problems, e.g. Computational Fluid Dynamics (CFD), terradynamics, block-diagram solvers like Scicos, Scicoslab and Simulink, using a simple C, C++ or Python peer-side API. MBDyn is being actively developed and used in the aerospace (aircraft, helicopters, tiltrotors, spacecraft), wind energy (wind turbines), automotive (cars, trucks) and mechatronic fields (industrial robots, parallel robots, micro aerial vehicles (MAV)) for analysis and simulation of complex systems dynamics. The extension of available analysis domains to new models and the introduction of new analysis domains is planned, and problem-driven: if you need to solve a specific problem, let us know. Run-time loading of user-defined modules is leveraged to let users extend the feature library (elements, drives, constitutive laws, and more). On GNU/Linux, real-time execution is supported under RTAI, the Real-Time Application Interface, and POSIX tight scheduling.",
+    "url": "http://www.mbdyn.org/",
+    "category": "Science and medicine",
+    "topics": [
+      "robotics",
+      "scientific computing",
+      "multibody dynamics",
+      "aeroelasticity",
+      "Structural engineering"
+    ],
+    "technologies": [
+      "python",
+      "c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://public.gitlab.polimi.it/DAER/mbdyn/-/wikis/GSoc-Project-Ideas"
+  },
+  {
+    "name": "MDAnalysis",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/mdanalysis/kf8rugznsqeskumi-360.png",
+    "image_background_color": null,
+    "description": "MDAnalysis is a Python library for the analysis of computer simulations of many-body systems at the molecular scale, spanning use cases from interactions of drugs with proteins to novel materials. It is written by scientists for scientists and is used for cutting edge research in biophysics, chemistry, soft-matter physics, and materials research around the world in academia and national research labs. MDAnalysis strives to be highly interoperable and hence a growing number of projects use MDAnalysis as their foundational library or integrate it.\n\nThe goal of MDAnalysis is to make it easy for users to analyze data that are produced by simulations (primarily molecular dynamics simulations) that run on some of the largest supercomputers in the world. MDAnalysis accomplishes this goal by providing a toolkit of programming building blocks that provide an abstract Python interface to the simulation data — agnostic of the specific simulation package that produced it — that lends itself to interactive data exploration and rapid prototyping but is also a robust foundational library that can form the basis for new computational tools.\n\nMDAnalysis allows one to read particle-based trajectories such as the ones produced by MD simulations or individual coordinate frames (such as biomolecules in the Protein Databank format) and access the atomic coordinates through NumPy arrays. Together with a powerful selection language and many implemented analysis algorithms, MDAnalysis provides a flexible and fast framework for complex analysis tasks. Welcoming documentation such as the User Guide https://userguide.mdanalysis.org/ make it easy to get started. New releases are downloaded a few thousand times and the academic papers describing MDAnalysis are cited more than almost two thousand times, indicating the widespread use in the academic community.",
+    "url": "https://www.mdanalysis.org",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "science",
+      "computational-chemistry",
+      "high-performance-computing",
+      "molecular-simulation",
+      "machine-learning"
+    ],
+    "technologies": [
+      "python",
+      "cython",
+      "c/c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/MDAnalysis/mdanalysis/wiki/GSoC-2026-Project-Ideas"
+  },
+  {
+    "name": "Meshery",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/meshery/4ywkbdszwd1sw2rq-360.png",
+    "image_background_color": null,
+    "description": "As a self-service engineering platform, Meshery enables collaborative design and operation of cloud and cloud native infrastructure.\n\nMeshery is for all cloud and cloud native infrastructure.  Kubernetes-centric. Kubernetes not required.\n\nInfrastructure diversity is a reality for any enterprise. Whether you’re running a single Kubernetes cluster or multiple Kubernetes clusters, on one cloud or multiple clouds, you’ll find that Meshery supports your infrastructure diversity (or lack thereof).\n\nMeshery is for engineering teams. Whether you are a Platform Engineer, Site Reliability Engineer, DevOps Engineer, Developer, or Operator, Meshery provides a platform for you to collaborate on the design and operation of your cloud native infrastructure.\n\nWhether making a Day 0 adoption choice, a Day 1 configuration and provisioning, or maintaining a Day 2 deployment, Meshery has useful capabilities in either circumstance. Targeted audience for Meshery project would be any technology operators that leverage Cloud and cloud native infrastructure.\n\nMeshery is like Google Docs for DevOps. Using Meshery extensions you can freely collaborate across projects and team with multi-player infrastructure design and operation.\n\nMeshery enables cloud native best practices with design patterns and the Meshery Catalog. Through Models, Meshery describes infrastructure under management, enabling you to define cloud native designs and patterns and then to export those designs and share within the Meshery Catalog.",
+    "url": "https://meshery.io",
+    "category": "Infrastructure and cloud, Development tools",
+    "topics": [
+      "collaboration",
+      "devops",
+      "Platform Engineering",
+      "cloud native infrastructure",
+      "infrastructure as design"
+    ],
+    "technologies": [
+      "javascript",
+      "golang",
+      "kubernetes",
+      "ai",
+      "visual design"
+    ],
+    "contact_email": "https://meshery.io/subscribe",
+    "projects_url": "https://meshery.io/programs/gsoc/2026"
+  },
+  {
+    "name": "MetaBrainz Foundation Inc",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/metabrainz-foundation-inc/m7lax42edddowwnl-360.png",
+    "image_background_color": null,
+    "description": "The MetaBrainz Foundation is a non-profit that believes in free, open access to data. It has been set up to build community maintained databases and make them available in the public domain or under Creative Commons licenses.\n\nOur data is mostly gathered by volunteers and verified by peer review to ensure it is consistent and correct. All non-commercial use of this data is free, but commercial users are asked to support us in order to help fund the project. We encourage all data users to contribute to the data gathering process so that our data can be as comprehensive as possible.\n\nWith this data we are building a music social network and bias free music recommendations.",
+    "url": "https://metabrainz.org",
+    "category": "Data, Media",
+    "topics": [
+      "machine learning",
+      "open data",
+      "music",
+      "books",
+      "music social network"
+    ],
+    "technologies": [
+      "python",
+      "machine learning",
+      "perl",
+      "postgres",
+      "spark"
+    ],
+    "contact_email": "suppport@metabrainz.org",
+    "projects_url": "https://wiki.musicbrainz.org/Development/Summer_of_Code/2026"
+  },
+  {
+    "name": "Micro Electronics Research Lab - UITU",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/micro-electronics-research-lab-uitu/el9byq6f4dfc1y77-360.png",
+    "image_background_color": null,
+    "description": "A non-profit organization fostering research on IoT, AI and ML based architectures leveraging the open-source RISC-V ISA. The main purpose of this Lab is to train undergraduate students for future Silicon industry.",
+    "url": "https://www.merledupk.org",
+    "category": "Other, Infrastructure and cloud",
+    "topics": [
+      "iot",
+      "embedded",
+      "Processor",
+      "System on Chip",
+      "RISC-V"
+    ],
+    "technologies": [
+      "RISCV",
+      "Processor",
+      "Hardware",
+      "systemonchip",
+      "memory"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/merledu/Google-Summer-of-Code/wiki/GSoC'26-Project-Ideas-List"
+  },
+  {
+    "name": "MIT App Inventor",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/mit-app-inventor/8ppq0spvr3j3gx8q-360.png",
+    "image_background_color": null,
+    "description": "MIT App Inventor is a free, open source web app that anyone can use to build mobile apps. It has been used by over 8 million people worldwide who have built more than 30 million apps. It is available in twelve different languages and used by people from ages 13 and up.",
+    "url": "http://appinventor.mit.edu",
+    "category": "Development tools, Artificial Intelligence",
+    "topics": [
+      "education",
+      "development tools",
+      "android",
+      "ios"
+    ],
+    "technologies": [
+      "javascript",
+      "java",
+      "gwt",
+      "swift"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/mit-cml/appinventor-sources/wiki/Google-Summer-of-Code-2026"
+  },
+  {
+    "name": "Mixxx",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/mixxx/ivlj1kl8jabpmfs9-360.png",
+    "image_background_color": null,
+    "description": "Mixxx is a feature rich DJ mixing  application. It supports many MIDI and HID DJ controllers, runs on Win Linux and MacOs. It supports effects, harmonic mixing and beatmatching.\n\nMixxx has an unusually broad community for an open-source project, encompassing performing musicians, C++ addicts, amateur DJs, Internet radio broadcasters, and casual users.",
+    "url": "https://mixxx.org",
+    "category": "End user applications",
+    "topics": [
+      "music",
+      "dj",
+      "streaming"
+    ],
+    "technologies": [
+      "javascript",
+      "c++",
+      "qt",
+      "pytorch",
+      "onnx"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/mixxxdj/mixxx/wiki/GSOC-2026-Ideas"
+  },
+  {
+    "name": "National Resource for Network Biology (NRNB)",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/national-resource-for-network-biology-nrnb/5uobjboaxnzrxyoj-360.png",
+    "image_background_color": null,
+    "description": "The National Resource for Network Biology (NRNB, https://nrnb.org) organizes the development of free, open-source software technologies to enable network-based visualization, analysis, and biomedical discovery. Biomedical research is increasingly dependent on knowledge expressed in terms of networks, including gene, protein and drug interactions, cell-cell and viral-host communication, and vast social networks. Our technologies enable researchers to assemble and analyze these networks and to use them to better understand biological systems and, in particular, how they fail in disease. \nThe NRNB mentoring organization includes projects such as Cytoscape (https://cytoscape.org/), WikiPathways (https://wikipathways.org/), SBML (https://sbml.org/), SBGN (https://sbgn.github.io/) and others. This is a great opportunity to work at the intersection of biology and computing! For example, Cytoscape is downloaded over 24,000 times per month by researchers. We take mentoring seriously and are proud of our 96% success rate (https://nrnb.org/alumni.html#gsoc-tab) with former students and projects. But don’t take our word for it, read testimonials from prior NRNB students (https://nrnb.org/testimonials.html#student-tab) and mentors (https://nrnb.org/testimonials.html#mentor-tab). \nFind out more about the software projects being developed in coordination with NRNB at our website (https://nrnb.org). Also refer to our GSoC page (https://nrnb.org/gsoc.html) for additional resources and application tips.",
+    "url": "https://nrnb.org",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "machine learning",
+      "web application",
+      "data science",
+      "scientific computing",
+      "network biology"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "html",
+      "css",
+      "LLM"
+    ],
+    "contact_email": "kristina.hanspers@gladstone.ucsf.edu",
+    "projects_url": "https://github.com/nrnb/GoogleSummerOfCode/issues"
+  },
+  {
+    "name": "Neovim",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/neovim/wsjrusphcrjmo5tf-360.png",
+    "image_background_color": null,
+    "description": "Neovim is a fork of the Vim text editor, designed for extensibility and usability.",
+    "url": "https://neovim.io/",
+    "category": "End user applications, Development tools",
+    "topics": [
+      "ai",
+      "editor",
+      "text-editor"
+    ],
+    "technologies": [
+      "c",
+      "lua",
+      "Zig"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/neovim/neovim/wiki/Google-Summer-of-Code"
+  },
+  {
+    "name": "Neuroinformatics Unit",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/neuroinformatics-unit/ebzgcbxkxvbe9igk.png",
+    "image_background_color": null,
+    "description": "The Neuroinformatics Unit is dedicated to the development of high quality, accurate, robust, easy to use and maintainable open-source software for neuroscience and machine learning. We collaborate with researchers and other software engineers to advance neuroscience research and make new algorithms and tools available to the global community.",
+    "url": "https://neuroinformatics.dev",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "visualization",
+      "neuroscience",
+      "data-science",
+      "Computer-Vision",
+      "neuroanatomy"
+    ],
+    "technologies": [
+      "python",
+      "numpy",
+      "pytorch",
+      "Scipy",
+      "napari"
+    ],
+    "contact_email": "hello@neuroinformatics.dev",
+    "projects_url": "https://neuroinformatics.dev/get-involved/gsoc/2026"
+  },
+  {
+    "name": "NumFOCUS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/numfocus/wimcwc2v6kjlidqc-360.png",
+    "image_background_color": null,
+    "description": "NumFOCUS supports and promotes world-class, innovative, open source scientific software. Most individual projects, even the wildly successful ones, find the overhead of a non-profit to be too large for their community to bear. NumFOCUS provides a critical service as an umbrella organization for this projects.",
+    "url": "https://numfocus.org",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "data science",
+      "graphics",
+      "ai",
+      "scientific computing",
+      "numerical computation"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "r",
+      "julia"
+    ],
+    "contact_email": "info@numfocus.org",
+    "projects_url": "https://github.com/numfocus/gsoc/blob/master/2026/ideas-list.md"
+  },
+  {
+    "name": "omegaUp",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/omegaup/uvgilx7vyspavjox-360.png",
+    "image_background_color": null,
+    "description": "omegaUp  is a non-profit organization (501c3) aimed to increase the number of talented Software Engineers in Latin America. Our open source platform omegaUp.com lets students immerse in a learning environment that fosters self paced learning of computer science skills with a democratic access to state-of-the-art learning tools.\n\nTeachers and tutors can create new coding challenges or use existing ones to start online programming competitions with local, national or even international reach, with automated grading of student's coding solutions. The omegaUp.com platform also enables teachers to leverage Competitive Programming tools and concepts inside the classroom to improve their educational experience.",
+    "url": "https://omegaup.org",
+    "category": "End user applications, Web",
+    "topics": [
+      "education",
+      "web",
+      "cloud",
+      "edtech",
+      "UX/UI"
+    ],
+    "technologies": [
+      "python",
+      "mysql",
+      "php",
+      "typescript",
+      "vue.js"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Google-Summer-of-Code-2026.md"
+  },
+  {
+    "name": "Open Climate Fix",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-climate-fix/k4retnlmzqbkc6bn-360.png",
+    "image_background_color": null,
+    "description": "Open Climate Fix is a non-profit product lab, developing state-of-the-art renewable energy forecasts to decarbonize the electricity grid.",
+    "url": "https://www.openclimatefix.org",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "Forecasting",
+      "Climate",
+      "renewables"
+    ],
+    "technologies": [
+      "python",
+      "pytorch"
+    ],
+    "contact_email": "peter@openclimatefix.org",
+    "projects_url": "https://docs.google.com/spreadsheets/d/14BF5NT8k-S-mMdKCTNrXjZKQTJZ30Kil35gAtQskSzg/edit?usp=sharing"
+  },
+  {
+    "name": "Open Food Facts",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-food-facts/ypo4wfmbo5ueujuf-360.png",
+    "image_background_color": null,
+    "description": "Open Food Facts is the \"Wikipedia of food\". Our community collects information about all the food products in the world, using mobile phones to help people make better choices for themselves and the planet, and to transform the whole food system along the way.\nWe do so using mobile crowdsourcing, community involvement and machine learning,",
+    "url": "https://world.openfoodfacts.org/discover",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "open data",
+      "health",
+      "environment",
+      "mobile",
+      "food"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "machine learning",
+      "perl",
+      "flutter"
+    ],
+    "contact_email": "contact@openfoodfacts.org",
+    "projects_url": "https://wiki.openfoodfacts.org/GSOC/2026_ideas_list"
+  },
+  {
+    "name": "Open HealthCare Network",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-healthcare-network/eutslgqeknc9vlgd-360.png",
+    "image_background_color": null,
+    "description": "Open Healthcare Network (OHC), originally established as Coronasafe Network, is a pioneering open-source organization dedicated to enhancing healthcare delivery and management. At the core of OHC's innovation is its flagship Electronic Medical Record (EMR) system, recognized as the 50th Digital Public Good by the United Nations. This system transcends being merely a digital repository of patient records, evolving into a platform that supports advanced TeleICU capabilities.\n\nOHC represents a unique fusion of professional expertise and community-driven innovation, primarily fueled by a small team of dedicated developers and a dynamic community of college students. This collaborative model showcases a new paradigm in healthcare technology, emphasizing impactful, sustainable, and scalable solutions.\n\nOriginally a volunteer-driven initiative during the COVID-19 pandemic, OHC has continually addressed citizen-level healthcare problems. Its CARE software, adopted by several Indian states, played a crucial role in optimizing healthcare resource management during the pandemic. As the pandemic waned, CARE evolved to support the 10BedICU Project, enabling technology-driven ICU care in rural India and providing TeleICU services to the remotest regions, impacting thousands of lives.\n\nToday, beyond the 10BedICU Project, CARE is being adopted for various healthcare applications, including palliative care digitization, demonstrating its adaptability and growing significance in improving healthcare delivery across diverse settings. OHC's journey is a testament to the transformative impact of youth-driven initiatives in healthcare, touching the lives of millions across India.",
+    "url": "https://ohc.network/",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "electronic medical records",
+      "Digital Public Goods",
+      "Telemedicine and Remote Care",
+      "AI in Health",
+      "HMIS"
+    ],
+    "technologies": [
+      "python",
+      "django",
+      "react",
+      "typescript",
+      "NextJs"
+    ],
+    "contact_email": "mohammed.nihal@egovernments.org",
+    "projects_url": "https://github.com/ohcnetwork/care_fe/issues?q=is%3Aissue%20state%3Aopen%20label%3AGSoC"
+  },
+  {
+    "name": "Open Robotics",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-robotics/6pg3nwfpieq1qmqw-360.png",
+    "image_background_color": null,
+    "description": "Open Robotics supports the development, distribution, and adoption of open source software for use in robotics research, education, and product development. Open Robotics is an umbrella organization encompassing five projects: \n- Robot Operating System (ROS), a robot development framework.\n- Gazebo, a robot simulation framework.\n- Open-RMF, a framework for coordinating multiple fleets of robots.\n- ros-controls, an extensive control framework built for ROS.\n- The ROS Infrastructure that is used to build and distribute ROS packages.",
+    "url": "https://www.openrobotics.org/",
+    "category": "End user applications, Artificial Intelligence",
+    "topics": [
+      "robotics",
+      "simulation",
+      "Hardware Control",
+      "fleet management",
+      "buildfarms"
+    ],
+    "technologies": [
+      "python",
+      "ros",
+      "gazebo",
+      "c++",
+      "Bevy"
+    ],
+    "contact_email": "gsoc@openrobotics.org",
+    "projects_url": "https://github.com/osrf/osrf_wiki/wiki/GSoC-2026"
+  },
+  {
+    "name": "Open Science Initiative for Perfusion Imaging",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-science-initiative-for-perfusion-imaging/bxlqptrs5g0ovtqz-360.png",
+    "image_background_color": null,
+    "description": "Perfusion Magnetic Resonance Imaging (MRI) is a vital medical imaging technique that assesses blood flow in tissues and thus contributes crucial information for diagnosing conditions such as stroke, tumors, and neurological disorders. Unlike the standard MRI methods that are daily used in hospitals, raw perfusion MRI data require further processing and quantification. This requires dedicated software tools. However, the lack of standardization and the availability of standardized and tested analysis code makes perfusion MRI less accessible and hinders its widespread use. The ISMRM Open Science Initiative for Perfusion Imaging (OSIPI) aims to address this gap and create resources for best practices in perfusion MRI including software and data inventories, code repositories, challenges, and educational material.",
+    "url": "https://osipi.ismrm.org/",
+    "category": "Science and medicine",
+    "topics": [
+      "artificial intelligence",
+      "data visualization",
+      "data analysis",
+      "medical imaging",
+      "reproducible science"
+    ],
+    "technologies": [
+      "python",
+      "github"
+    ],
+    "contact_email": "ismrmosipi@gmail.com",
+    "projects_url": "https://docs.google.com/document/d/e/2PACX-1vTs3n_pm3ZM7t-6rKooThwrBtCRQMCkYJcbIyl0ekhm5O4jBgC0BqdBDFKVUDhDvbFM1ShBoV3Q2pFM/pub"
+  },
+  {
+    "name": "Open Science Labs",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-science-labs/rjv8l7mrkiwlv9ab-360.png",
+    "image_background_color": null,
+    "description": "Open Science Labs is a global community dedicated to creating an open space for\nteaching, learning, and sharing information about open science and computational\ntools. Our community develops tools that address real-world problems and\ncollaborates with other projects and workgroups to improve technology and create\ninternational opportunities for our community. Although our focus may seem\nbroad, we initially prioritize supporting Research Software Engineers (RSEs) who\noften face computational challenges in their work. We recognize that many\ncolleagues in scientific fields may not be familiar with programming languages,\ncomputational libraries, version control systems, databases, DevOps, and other\ncomputational tools. Therefore, we aim to provide a safe and open space for\nindividuals to learn and share their knowledge. Our community is open to\neveryone, including students, professors, and industry professionals, as we\nbelieve that the challenges and technologies used in these fields are frequently\nsimilar, if not the same (in many cases).",
+    "url": "https://opensciencelabs.org",
+    "category": "Science and medicine, Development tools",
+    "topics": [
+      "web",
+      "ai",
+      "devops",
+      "devtools",
+      "open-science"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "llvm",
+      "c++",
+      "docker"
+    ],
+    "contact_email": "",
+    "projects_url": "https://opensciencelabs.org/opportunities/gsoc/project-ideas"
+  },
+  {
+    "name": "Open Technologies Alliance - GFOSS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-technologies-alliance-gfoss/kiyijull8pfdypve-360.png",
+    "image_background_color": null,
+    "description": "Open Technologies Alliance (GFOSS)  is a non-profit organization, with 37 Universities and Research Centers as its shareholders. Our main goal is to promote Openness.\nGFOSS – Open Technologies Alliance  is a platform for Open Standards, Free Software, Open Content, Open Data & Open Hardware in Greece. The major Greek Universities and Research Centers participate in GFOSS – Open Technologies Alliance, while leading members of the Greek community of developers play a key role in the implementation of our policies. Through our initiatives we aspire to contribute and coordinate the efforts of groups of volunteers, public servants, university researchers and students enabling them to form the backbone of Greek FOSS development and implementation. GFOSS is one of the strategic actors for the promotion of OSS throughout Greece (see https://joinup.ec.europa.eu/sites/default/files/inline-files/OSS%20Country%20Intelligence%20Report_GR.pdf ). Many public administrations and academic institutions collaborate with GFOSS to implement open source projects and through Google Summer of Code we give the opportunity to students to actively engage in the production and the actual implementation of an open source project. GFOSS also contributes and advises on the development of various open source projects related to e-government and digital transformation in Greece (e.g. https://howto.gov.gr/ - https://forma.gov.gr/) and actively promotes the use of Open Source software and hardware in the Greek primary and secondary education through the Open Educational Technologies Competition (https://openedtech.ellak.gr/ )",
+    "url": "http://www.gfoss.eu",
+    "category": "Science and medicine, Development tools, Artificial Intelligence",
+    "topics": [
+      "web",
+      "robotics",
+      "open hardware",
+      "c++",
+      "Artificial Inteligence"
+    ],
+    "technologies": [
+      "javascript",
+      "c/c++",
+      "nodejs",
+      "python 3",
+      "Machine Learning (ML)"
+    ],
+    "contact_email": "info@eellak.gr",
+    "projects_url": "https://ellak.gr/wiki/index.php?title=Google_Summer_of_Code_2026_proposed_ideas"
+  },
+  {
+    "name": "Open Transit Software Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/open-transit-software-foundation/uz3p7k5vsxduhrhk-360.png",
+    "image_background_color": null,
+    "description": "We are the home for the OneBusAway project. OneBusAway is a suite of open source transit information tools based on real-time vehicle data.\n\nOneBusAway is a suite of open source transit information tools that enable transit agencies to provide real-time vehicle locations, alerts, and arrival information to riders, with iOS and Android apps, a web platform, and robust APIs, as well as back office support. OneBusAway lets transit agencies be in control, without needing to build everything themselves and without cutting corners.",
+    "url": "https://opentransitsoftwarefoundation.org",
+    "category": "End user applications, Web",
+    "topics": [
+      "apps",
+      "Transit",
+      "travel",
+      "bus"
+    ],
+    "technologies": [
+      "android",
+      "java",
+      "golang",
+      "docker",
+      "ios"
+    ],
+    "contact_email": "",
+    "projects_url": "https://opentransitsoftwarefoundation.org/2026/01/google-summer-of-code-2026-project-ideas/"
+  },
+  {
+    "name": "OpenAFS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openafs/hhf0h2zemmqes7kt-360.png",
+    "image_background_color": null,
+    "description": "OpenAFS is a distributed filesystem originally developed at Carnegie Mellon University and IBM. It offers a client-server architecture for federated file sharing and replicated read-only content distribution, providing location independence, scalability, security, and transparent migration capabilities. OpenAFS is available for a broad range of systems including UNIX, Linux,  MacOS X, and Microsoft Windows.",
+    "url": "https://www.openafs.org",
+    "category": "Operating systems, Infrastructure and cloud",
+    "topics": [
+      "testing",
+      "kernel",
+      "network",
+      "storage",
+      "filesystems"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "javascript",
+      "git",
+      "tcp/udp"
+    ],
+    "contact_email": "foundation@openafs.org",
+    "projects_url": "https://www.openafs.org/gsoc/project-ideas.html"
+  },
+  {
+    "name": "OpenAstronomy",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openastronomy/3wvadxwxjc2arepg-360.png",
+    "image_background_color": null,
+    "description": "OpenAstronomy is a collaboration between open source astronomy, astrophysics & heliophysics projects that are used by researchers and software engineers around the world to study our universe either by analysing the data obtained from amazing instruments like the [James Webb Space telescope](https://jwst.nasa.gov/), the [Square Kilometer Array](https://www.skatelescope.org/) or the [Solar Dynamic Observatory](http://sdo.gsfc.nasa.gov/), developing very sophisticated numerical models (eg., [FLASH](http://flash.uchicago.edu/)) or designing interplanetary trajectories for human-made spacecraft. The analysis of such data helps multiple types of research, from being able to forecast solar storms to detecting planets in other stars, to understanding how galaxies are formed to explain the expansion and the origin of the universe.\n\nOpenAstronomy currently consists of [18 projects](https://openastronomy.org/members/) that develop tools, the range of which is wide. \nFor example: \n- [Astropy](https://www.astropy.org/) is a general Python library for astronomy, providing common tools such as celestial coordinates, image processing, tabular data, reading and writing, units and support for astronomy-specific file formats; \n- [SunPy](https://sunpy.org/) provides utilities for obtaining and representing solar physics data, with access to the largest online solar physics data archives and solar specific analysis tools and visualisation code;\n- [Julia Astro](https://juliaastro.org/dev/index.html) is a set of packages for general astronomy and astrophysics analysis using Julia;\n- And more!\n\nAs a single organisation, we strive to strengthen collaborations between each sub-organisation, and at the same time increase the awareness among our users on the capabilities of our \"sister\" projects. With the goal being unification of standards and libraries to enable true multidisciplinary research.",
+    "url": "https://openastronomy.org/",
+    "category": "Science and medicine",
+    "topics": [
+      "image processing",
+      "astronomy",
+      "data analysis",
+      "solar physics",
+      "high energy astrophysics"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "c++",
+      "julia"
+    ],
+    "contact_email": "openastronomy.organization@gmail.com",
+    "projects_url": "https://openastronomy.org/gsoc/gsoc2026/#/projects"
+  },
+  {
+    "name": "OpenCV",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/opencv/fmh9fnybaz97kodm-360.png",
+    "image_background_color": null,
+    "description": "OpenCV promotes the beneficial uses of computer vision in society primarily through maintaining a state-of-the-art open and free code base and via courseware, contests, workshops and conferences. \n\nOpenCV, the Open Source Computer Vision Library includes state of the art computer vision and deep learning algorithms (including running deep networks) and apps. It is professionally coded and optimized. It can be used in C++, Python, javascipt, Julia, Cuda, OpenCL and Matlab. It runs on: Android, iOS, Windows, Linux and MacOS and many embedded implementations such as Raspberry Pi, Movidius, and RISC-V.",
+    "url": "https://opencv.org/",
+    "category": "Media, Artificial Intelligence",
+    "topics": [
+      "robotics",
+      "computer vision",
+      "ai",
+      "deep learning"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "deep learning",
+      "ai"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/opencv/opencv/wiki/GSoC_2026"
+  },
+  {
+    "name": "OpenELIS Global",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openelis-global/k6rnzk3hcktzabst-360.png",
+    "image_background_color": null,
+    "description": "OpenELIS Global  (Open Enterprise laboratory Information System) is an open-source, standards-based, and secure lab information system for labs of any size and need.\n\nIt is an enterprise-level laboratory information system built on open-source web-based technologies that has been tailored for low- and middle-income country public health laboratories.\n\nThe software serves as both an effective laboratory software solution and a business process framework. It supports the effective functioning of public health laboratories for best laboratory practice and accreditation.",
+    "url": "https://openelis-global.org/",
+    "category": "Science and medicine",
+    "topics": [
+      "Health Care",
+      "Laboratory Information System"
+    ],
+    "technologies": [
+      "postgresql",
+      "javascript",
+      "java",
+      "react",
+      "spring"
+    ],
+    "contact_email": "",
+    "projects_url": "https://uwdigi.atlassian.net/wiki/spaces/OG/pages/931594241/GSoC+2026"
+  },
+  {
+    "name": "OpenMRS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openmrs/evthgp3dhsqx5kyx-360.png",
+    "image_background_color": null,
+    "description": "OpenMRS provides the foundational, electronic medical record technology for more than 6,500 health facilities in over 80 countries, touching and helping millions of patients throughout  the world.  \n\nThe OpenMRS Community’s mission is to improve healthcare delivery in resource-constrained environments. \n\nWe coordinate a global community that creates and sustains a robust, scalable, user-driven and open-source medical record platform and reference frontend application.\n\nWe maintain a platform that countries and implementers use to create a customized EMR system in response to actual needs on the ground.",
+    "url": "https://openmrs.org/",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "platform",
+      "frontend",
+      "Electronic Medical Record System",
+      "QA automation"
+    ],
+    "technologies": [
+      "mysql",
+      "javascript",
+      "java",
+      "reactjs",
+      "fhir"
+    ],
+    "contact_email": "",
+    "projects_url": "https://openmrs.atlassian.net/wiki/spaces/RES/pages/752844801/Summer+of+Code+2026"
+  },
+  {
+    "name": "OpenMS",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openms/oltxzjcwcupftoxu-360.png",
+    "image_background_color": null,
+    "description": "OpenMS is an open-source C++ software library for mass spectrometry data management and analysis with python wrappers. OpenMS houses an expansive modular toolset and ready-to-use scientific workflows in Galaxy, KNIME and nextflow.",
+    "url": "https://openms.de",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "automation",
+      "deep learning",
+      "algorithms",
+      "webdev"
+    ],
+    "technologies": [
+      "python",
+      "cython",
+      "c++",
+      "r",
+      "pytorch"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.openms.org/news/gsoc2026/"
+  },
+  {
+    "name": "OpenStreetMap",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openstreetmap/ihw4tczyumj0yx81-360.png",
+    "image_background_color": null,
+    "description": "OpenStreetMap is a crowdsourcing project that creates and distributes free geographic data for the world. Our data is collected by hundreds of thousands of contributors around the globe and released with an open-content license. We allow free access not only to our map products, but all the underlying map data, which powers websites and apps used by billions of people worldwide.\n\nOSM data can be freely used in both open and closed source software, and has attracted many commercial users. Still, the success of OSM wouldn't be possible without open source software and volunteer developers. The database, website and API running on our own servers, the editing tools used by contributors to improve the map, and many of the most popular libraries and end-user applications within the OSM software ecosystem are all open source software, and developed through a community-driven process.\n\nAs our Google Summer of Code participation spans this diverse set of software projects, most of which are maintained as independent efforts under the OSM umbrella, contributors will encounter a wide range of programming languages, paradigms and use cases. We hope that we have interesting challenges to offer for any developer, no matter their background!",
+    "url": "https://www.openstreetmap.org/",
+    "category": "Data, End user applications",
+    "topics": [
+      "databases",
+      "web",
+      "routing",
+      "ui",
+      "geodata"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "c++",
+      "docker",
+      "glTF"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.openstreetmap.org/wiki/Google_Summer_of_Code/2026/Project_ideas"
+  },
+  {
+    "name": "openSUSE Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/opensuse-project/zq11ebxj038xotbe-360.png",
+    "image_background_color": null,
+    "description": "The openSUSE Project is a worldwide effort that promotes the use of Linux, tools around it, and open source. The openSUSE community is made up of multiple contributing communities that collaborate as part of a global open-source network. The openSUSE community develops, builds and maintains many of the packages, tools and infrastructure for the distribution. The community works together in an open, transparent and friendly manner as part of the global Free and Open Source Software community. openSUSE creates one of the world's best Linux distributions, as well as a variety of tools, such as OBS, OpenQA, Kiwi, YaST, OSEM and Uyuni. Distributions include a rolling release (Tumbleweed), a stable annual release (Leap) and operating systems for edge, embedded, cloud and containers through MicroOS and ALP.\n\nThe project is controlled by its community and relies on the contributions of individuals, working as testers, writers, translators, usability experts, artists and ambassadors or developers. The project embraces a wide variety of technology, people with different levels of expertise, speaking different languages and having different cultural backgrounds.",
+    "url": "https://get.opensuse.org/",
+    "category": "Operating systems, Development tools",
+    "topics": [
+      "AIML",
+      "operating system developer tools",
+      "containers kubernetes",
+      "Security Cryptography",
+      "systems management"
+    ],
+    "technologies": [
+      "python",
+      "c/c++",
+      "go",
+      "ruby",
+      "reactjs javascript"
+    ],
+    "contact_email": "ddemaio@opensuse.org",
+    "projects_url": "https://github.com/openSUSE/mentoring/issues"
+  },
+  {
+    "name": "OpenVINO Toolkit",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openvino-toolkit/ivzvok335ujezk2z-360.png",
+    "image_background_color": null,
+    "description": "OpenVINO is an open‑source toolkit designed to optimize and deploy deep learning models from cloud to edge. It accelerates inference for a wide range of use cases—including computer vision, generative AI, and agentic AI—supporting models from popular frameworks such as PyTorch, TensorFlow, ONNX, and more. With OpenVINO, you can convert and optimize models, then deploy them across diverse Intel hardware and environments, whether on-premises, at the edge, on AI PCs, or in the cloud.",
+    "url": "https://docs.openvino.ai/",
+    "category": "Development tools, Artificial Intelligence",
+    "topics": [
+      "ai",
+      "inference",
+      "gen ai",
+      "Agentic AI",
+      "Model Serving"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "arm",
+      "x86"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/openvinotoolkit/openvino/wiki/Google-Summer-Of-Code#project-ideas-for-2026"
+  },
+  {
+    "name": "OpenWISP",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/openwisp/xgfy0r7femccwzvj-360.png",
+    "image_background_color": null,
+    "description": "OpenWISP is an open source network management system which runs on low cost hardware and can be used to manage networks: from public wifi, university wifi, to mesh networks and IoT.",
+    "url": "https://openwisp.org",
+    "category": "End user applications, Web",
+    "topics": [
+      "networking",
+      "network management system",
+      "wifi",
+      "vpn",
+      "sdn"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "django",
+      "lua",
+      "openwrt"
+    ],
+    "contact_email": "",
+    "projects_url": "https://openwisp.io/docs/dev/developer/gsoc-ideas-2026.html"
+  },
+  {
+    "name": "Oppia Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/oppia-foundation/nqvgy9fm3aqshwtv-360.png",
+    "image_background_color": null,
+    "description": "The Oppia project aims to empower learners across the globe by providing access to high-quality, engaging education. We envision a world where access to high-quality education is not a privilege but a human right. \n\nThe team works on two platforms: \n\n    (a) Oppia Web, which provides an online learning tool that enables anyone to learn from effective and engaging interactive lessons (called 'explorations'), which simulate a one-on-one conversation with a tutor. This format makes it possible for students to learn by doing while getting feedback. The Oppia Web platform also provides the infrastructure needed to support lesson creation and translation.\n\n    (b) Oppia Android, which provides a way for these lessons to be played offline on an Android app that supports low-end devices and does not require Internet connectivity. \n\nAs a community, we are also aware that millions of students in underserved communities lack access to the educational resources necessary to effectively learn key skills like basic numeracy. Thus, in addition to developing the Oppia platform, the team has launched and continues to develop a set of free and effective lessons on basic mathematics, supplemented by translations and voiceovers. Students using these lessons have shown strong improvements between pre-and post-tests, and we’ve received lots of positive feedback on them. We are planning to extend this offering to other subjects, based on what students (and the nonprofits working with them) tell us would be most useful.",
+    "url": "https://www.oppia.org",
+    "category": "End user applications, Artificial Intelligence",
+    "topics": [
+      "education",
+      "web",
+      "ai",
+      "nonprofit",
+      "social impact"
+    ],
+    "technologies": [
+      "python",
+      "google app engine",
+      "angular",
+      "typescript",
+      "Apache Beam"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/oppia/oppia/wiki/Google-Summer-of-Code-2026"
+  },
+  {
+    "name": "Organic Maps",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/organic-maps/cnhed0elppzqsjut-360.png",
+    "image_background_color": null,
+    "description": "Organic Maps is the ultimate companion app for travelers, tourists, hikers, cyclists and drivers:\n\n- Detailed offline maps with places that don't exist on other maps, thanks to OpenStreetMap\n- Cycling routes, hiking trails, and walking paths\n- Contour lines, elevation profiles, peaks, and slopes\n- Turn-by-turn walking, cycling, and car navigation with voice guidance\n- Fast offline search on the map\n- Bookmarks export and import in KML/KMZ, GPX, GeoJSON formats\n- Dark Mode to protect your eyes\n- Countries and regions don't take a lot of space\n- Free and open-source\n\nOrganic Maps is pure and organic, made with love:\n\n- Respects your privacy\n- Saves your battery\n- No unexpected mobile data charges",
+    "url": "https://organicmaps.app",
+    "category": "End user applications",
+    "topics": [
+      "privacy",
+      "maps",
+      "navigation",
+      "mobile",
+      "offline"
+    ],
+    "technologies": [
+      "android",
+      "java",
+      "c++",
+      "ios",
+      "OpenStreetMap"
+    ],
+    "contact_email": "join@organicmaps.app",
+    "projects_url": "https://github.com/organicmaps/organicmaps/wiki/GSoC-2026-ideas"
+  },
+  {
+    "name": "OSGeo (Open Source Geospatial Foundation)",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/osgeo-open-source-geospatial-foundation/yundulx00fbd1akm-360.png",
+    "image_background_color": null,
+    "description": "The Open Source Geospatial Foundation (OSGeo) is a not-for-profit organization whose mission is to foster global adoption of open geospatial technology by being an inclusive software foundation devoted to an open philosophy and participatory community-driven development.<br/><br/>\n\nOSGeo serves as an umbrella organization for the Open Source Geospatial community in general and several code projects in particular:<br/>\n* <b>Web Mapping</b>: deegree, geomajas, GeoMOOSE, GeoServer, Mapbender, MapFish, MapGuide Open Source, MapServer, OpenLayers.<br/>\n* <b>Desktop Applications</b>: GRASS GIS, gvSIG, Marble, QGIS.<br/>\n* <b>Geospatial Libraries</b>: FDO, GDAL/OGR, GEOS, GeoTools, OSSIM, PostGIS.<br/>\n* <b>Metadata Catalogues</b>: GeoNetwork, pycsw.<br/>\n* <b>Content Management Systems</b>: GeoNode.<br/>\n* <b>Community Projects</b>: pgRouting, istSOS, MetaCRS, Opticks, Orfeo ToolBox (OTB), PyWPS, Team Engine, ZOO-Project.<br/>\n* <b>Other (non-code) Projects</b>: GeoForAll (Education and Curriculum), OSGeoLive DVD, Public Geospatial Data.<br/><br/>\n\nWe host regional and international FOSS4G conferences with typical attendance of 500-1100+ geospatial developers, industry and government leaders, and researchers. Our mailing lists collectively go out to ~ 30,000 unique subscribers.",
+    "url": "https://www.osgeo.org/",
+    "category": "End user applications, Other",
+    "topics": [
+      "open science",
+      "gis",
+      "citizen science",
+      "geolocation",
+      "mapping"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "javascript",
+      "java",
+      "c++"
+    ],
+    "contact_email": "gsoc-admin@osgeo.org",
+    "projects_url": "https://wiki.osgeo.org/wiki/Google_Summer_of_Code_2026_Ideas"
+  },
+  {
+    "name": "OWASP Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/owasp-foundation/haks8qbp0yvjvzge-360.png",
+    "image_background_color": null,
+    "description": "As the world’s largest non-profit organization concerned with software security, OWASP:\n\n* Supports the building of impactful projects; \n* Develops & nurtures communities through events and chapter meetings worldwide; \n* Provides educational publications & resources\n\nin order to enable developers to write better software, and security professionals to make the world's software more secure.",
+    "url": "https://owasp.org",
+    "category": "Security",
+    "topics": [
+      "web",
+      "cloud",
+      "application security",
+      "cybersecurity",
+      "DevSecOps"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "java",
+      "ZAP",
+      "Juice Shop"
+    ],
+    "contact_email": "gsoc-admins@owasp.org",
+    "projects_url": "https://owasp.org/www-community/initiatives/gsoc/gsoc2026ideas"
+  },
+  {
+    "name": "PAL Robotics",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/pal-robotics/f3yidefsydweipcc-360.png",
+    "image_background_color": null,
+    "description": "PAL Robotics is a European company that specializes in developing humanoid robots and autonomous systems for research, service, and industrial applications. The company was founded in 2004 by a group of robotics experts with the aim of creating innovative solutions that can enhance the quality of life for people and support industry transformation.\n\nPAL Robotics headquarter is in Barcelona, Spain, and has a team of more than 100 professionals with diverse backgrounds in robotics, artificial intelligence, mechanical engineering, and software development. The company is recognized for its advanced humanoid robots, such as REEM-C, TALOS, and Kangaroo; its retail and intralogistics solutions Stockbot, TIAGo base and TIAGo Base AI; its Social robot ARI and its mobile manipulators TIAGo and TIAGo Pro. All these platforms are designed to interact with humans in a natural way, perform complex tasks, and operate in dynamic environments.",
+    "url": "https://pal-robotics.com/",
+    "category": "Other, Artificial Intelligence",
+    "topics": [
+      "robotics",
+      "reinforcement learning",
+      "web tools"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "c++"
+    ],
+    "contact_email": "gsoc@pal-robotics.com",
+    "projects_url": "https://pal-robotics.com/google-summer-of-code-2026-proposals/"
+  },
+  {
+    "name": "PEcAn Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/pecan-project/kijyzllr7r1g0ukz-360.png",
+    "image_background_color": null,
+    "description": "Climate change science has witnessed an explosion in the amount and types of data that can be brought to bear on the potential responses of the terrestrial carbon cycle and biodiversity to global change. Many of the most pressing questions about global change are not necessarily limited by the need to collect new data as much as by our ability to synthesize existing data. This project specifically seeks to improve this ability. Because no one measurement provides a complete picture, multiple data sources must be integrated in a sensible manner. Process-based models represent an ideal framework for integrating these data streams because they represent multiple processes at different spatial and temporal scales in ways that capture our current understanding of the causal connections across scales and among data types. Three components are required to bridge this gap between the available data and the required level of understanding: 1) state-of-the-art ecosystem model, 2) a workflow management system to handle the numerous streams of data, and 3) a data assimilation statistical framework in order to synthesize the data with the model.",
+    "url": "https://pecanproject.github.io/",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "data science",
+      "ecosystem models",
+      "scientific visualization",
+      "climate science",
+      "Ecological Forecasting,"
+    ],
+    "technologies": [
+      "r",
+      "docker",
+      "api",
+      "geospatial"
+    ],
+    "contact_email": "",
+    "projects_url": "https://pecanproject.github.io/gsoc_ideas"
+  },
+  {
+    "name": "Pharo Consortium",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/pharo-consortium/zrxygkl3ycuvw6nb-360.png",
+    "image_background_color": null,
+    "description": "Pharo is a dynamic, purely object-oriented programming language (where everything is an object) that is inspired by Smalltalk. It also includes a powerful IDE that focuses on simplicity and quick feedback. Its entire syntax can fit on a postcard, and you can code directly in the debugger. Pharo has useful tools that help you work efficiently.\n\nThe goal of Pharo is to provide a clean, innovative, free, and open-source environment. With a stable and small core system, great development tools, and regular updates, Pharo is a good choice for building and running important applications.\n\nPharo supports a healthy community made up of both private and commercial contributors who help improve and maintain the core system and its external packages.",
+    "url": "https://pharo.org/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "machine learning",
+      "programming languages",
+      "virtual machines",
+      "Modelling",
+      "Live music"
+    ],
+    "technologies": [
+      "git",
+      "smalltalk",
+      "pharo",
+      "spec",
+      "SUnit"
+    ],
+    "contact_email": "https://gsoc.pharo.org/ideas",
+    "projects_url": "https://gsoc.pharo.org/ideas"
+  },
+  {
+    "name": "Plone Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/plone-foundation/wivpatiziuhidzjw-360.png",
+    "image_background_color": null,
+    "description": "Plone is a Python-based CMS built with workflow and security at the forefront. It is developed by a world-wide community and uses modern technologies and techniques. It comes with a complete API and a React-based frontend. Also home to Guillotina.io, a full stack data framework, and the Zope and ZODB object database.",
+    "url": "https://plone.org",
+    "category": "Web",
+    "topics": [
+      "web",
+      "cms"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "react"
+    ],
+    "contact_email": "gsoc@cleanclothes.org",
+    "projects_url": "https://plone.org/community/gsoc/2026"
+  },
+  {
+    "name": "PostgreSQL",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/postgresql/hj9srl9x0o6iendy-360.png",
+    "image_background_color": null,
+    "description": "PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.",
+    "url": "https://postgresql.org",
+    "category": "Data, Web",
+    "topics": [
+      "web",
+      "database",
+      "ui",
+      "sql",
+      "Benchmark"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "postgresql",
+      "javascript",
+      "go"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.postgresql.org/wiki/GSoC_2026"
+  },
+  {
+    "name": "Processing Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/processing-foundation/xr2sncljbvtlop1n-360.png",
+    "image_background_color": null,
+    "description": "Our mission is to promote software learning within the arts, artistic learning within technology-related fields, and to celebrate the diverse communities that make these fields vibrant, liberatory, and innovative. Our goal is to support people of all backgrounds in learning how to program and make creative work with code, especially those who might not otherwise have access to tools and resources. We also believe that some of the most radical futures and innovative technologies are being built by communities that have been pushed to the margins by dominant tech. We hope to support those who have been marginalized by technology in continued self-determination by providing time, space, and resources.\n\nWe work toward our goals by developing and distributing a group of related software projects, which includes Processing (Java), p5.js (JavaScript), and p5.js Editor (JavaScript), and by facilitating partnerships and collaborations with allied organizations and individuals to build a more diverse community around software and the arts.",
+    "url": "http://processingfoundation.org",
+    "category": "Programming languages, Media",
+    "topics": [
+      "education",
+      "web",
+      "graphics",
+      "creative coding",
+      "design"
+    ],
+    "technologies": [
+      "javascript",
+      "java",
+      "typescript",
+      "webgl",
+      "GitHub Actions"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/processing/Processing-Foundation-GSoC/wiki/Project-Ideas-List-(GSoC-2026)#project-ideas-list"
+  },
+  {
+    "name": "Project Mesa",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/project-mesa/fh3o8surszufvjpv-360.png",
+    "image_background_color": null,
+    "description": "Mesa is an Apache2 licensed agent-based modeling (or ABM) framework in Python.\n\nIt allows users to quickly create agent-based models using built-in core components (such as spatial grids and agent schedulers) or customized implementations; visualize them using a browser-based interface; and analyze their results using Python’s data analysis tools. \n\nIts goal is to provide an ecosystem to support generative science approaches, improve understanding of complex systems and aid practical decision-making.",
+    "url": "https://mesa.readthedocs.io/latest/",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "simulation",
+      "Agent Based Models",
+      "Generative Science"
+    ],
+    "technologies": [
+      "python",
+      "gis",
+      "object oriented programming",
+      "LLMs",
+      "network topology"
+    ],
+    "contact_email": "maintainers@projectmesa.dev",
+    "projects_url": "https://github.com/mesa/mesa/wiki/GSoC-2026-Project-Ideas"
+  },
+  {
+    "name": "Prometheus-Operator",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/prometheus-operator/dpytdkpyfejrot7o-360.png",
+    "image_background_color": null,
+    "description": "The Prometheus Operator provides Kubernetes native deployment and management of Prometheus and related monitoring components. The purpose of this project is to simplify and automate the configuration of a Prometheus based monitoring stack for Kubernetes clusters.\n\nThe Prometheus operator includes, but is not limited to, the following features:\n\n* Kubernetes Custom Resources: Use Kubernetes custom resources to deploy and manage Prometheus, Alertmanager, and related components.\n\n* Simplified Deployment Configuration: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.\n\n* Prometheus Target Configuration: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.",
+    "url": "https://prometheus-operator.dev/",
+    "category": "Infrastructure and cloud",
+    "topics": [
+      "monitoring",
+      "cloud",
+      "observability",
+      "Kubernetes Operator"
+    ],
+    "technologies": [
+      "prometheus",
+      "go",
+      "kubernetes",
+      "kubernetes operators"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/prometheus-operator/community/blob/main/mentoring/gsoc/2026/project_ideas.md"
+  },
+  {
+    "name": "Python Software Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/python-software-foundation/2vpxhpvcsvgyx3kg-360.png",
+    "image_background_color": null,
+    "description": "Python is a programming language that lets you work more quickly and integrate your systems more effectively.\n\nThe Python Software Foundation serves as an umbrella organization to a\nvariety of Python-related projects, as well as sponsoring projects related to the\ndevelopment of the Python language.\n\nYou can view a full list of participating sub-orgs here:\nhttps://python-gsoc.org/ideas.html\n\nSub-orgs:\n- Borg Collective - backup tools\n- CVE Binary Tool - scanning for known security vulnerabilities\n- DIPY - 3d/4d+ imaging\n- Fury - scientific visualization tools\n- LPython - ahead of time compiler for python\n- MNE-Python - tools for human neurophysiological data\n- Mission Support System - atmospheric science tools for flight planning\n- PyData/Sparse - n-dimensional sparse arrays for pyData\n- PyElastica - simulation and modeling for slender structures",
+    "url": "https://python-gsoc.org/",
+    "category": "End user applications, Programming languages",
+    "topics": [
+      "security",
+      "visualization",
+      "compiler",
+      "modeling",
+      "Backup"
+    ],
+    "technologies": [
+      "python",
+      "javascript"
+    ],
+    "contact_email": "",
+    "projects_url": "https://python-gsoc.org/ideas.html"
+  },
+  {
+    "name": "QC-Devs",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/qc-devs/nywcx8edxlpsz2kg-360.png",
+    "image_background_color": null,
+    "description": "QC-Devs develops free, open-source, and cross-platform libraries for the computational sciences, focusing on theoretical and computational chemistry. Our goal is to make programming accessible to students and researchers, to catalyze scientific collaborations, and to promote precepts of sustainable software development. We're adapting some of the same principles to develop free and open-source educational materials (qc-edu.org) to modernize scientific education by integrating hands-on computation and computer programming.",
+    "url": "https://qcdevs.org/",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "data science",
+      "scientific visualization",
+      "quantum chemistry",
+      "Computational Science",
+      "numerical algorithms"
+    ],
+    "technologies": [
+      "python",
+      "github",
+      "c++",
+      "julia",
+      "jupyter"
+    ],
+    "contact_email": "qcdevs@qcdevs.org",
+    "projects_url": "https://qcdevs.org/join/qcdevs_gsoc/"
+  },
+  {
+    "name": "QEMU",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/qemu/gik5gsxljb3j1jx1-360.png",
+    "image_background_color": null,
+    "description": "The QEMU Project includes the QEMU open source machine emulator and virtualizer and also acts as an umbrella organization for the KVM Linux kernel module and rust-vmm community.\n\nWhen used as a machine emulator, QEMU can run operating systems and programs made for one machine (e.g. an ARM board) on a different machine (e.g. your own PC). By using dynamic translation, it achieves very good performance.\n\nWhen used as a virtualizer, QEMU achieves near native performances by executing the guest code directly on the host CPU. QEMU supports virtualization when executing under the Xen hypervisor or using the KVM kernel module in Linux. When using KVM, QEMU can virtualize x86, ARM, server and embedded PowerPC, and S390 guests.",
+    "url": "https://qemu.org/",
+    "category": "Infrastructure and cloud, Development tools",
+    "topics": [
+      "systems programming",
+      "kernel",
+      "compiler",
+      "emulator",
+      "hypervisor"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "linux",
+      "rust"
+    ],
+    "contact_email": "stefanha@gmail.com",
+    "projects_url": "https://wiki.qemu.org/Google_Summer_of_Code_2026"
+  },
+  {
+    "name": "R project for statistical computing",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/r-project-for-statistical-computing/7regeqcjh95nenso-360.png",
+    "image_background_color": null,
+    "description": "R provides a wide variety of statistical and graphical techniques, and is highly extensible. R is often the tool of choice for research in statistical methodology.\n\nR is an integrated suite of software facilities for data manipulation, calculation and graphical display. It includes\n\n* an effective data handling and storage facility,\n* a suite of operators for calculations on arrays, in particular matrices,\n* a large, coherent, integrated collection of intermediate tools for data analysis,\n* graphical facilities for data analysis and display either on-screen or on hardcopy, and\n* a well-developed, simple and effective programming language which includes conditionals, loops, user-defined recursive functions and input and output facilities.\n\nThe term “environment” is intended to characterize it as a fully planned and coherent system, rather than an incremental accretion of very specific and inflexible tools, as is frequently the case with other data analysis software.\n\nR, like S, is designed around a true computer language, and it allows users to add additional functionality by defining new functions. Much of the system is itself written in the R dialect of S, which makes it easy for users to follow the algorithmic choices made. For computationally-intensive tasks, C, C++ and Fortran code can be linked and called at run time. Advanced users can write C code to manipulate R objects directly.\n\nMany users think of R as a statistics system. We prefer to think of it of an environment within which statistical techniques are implemented. R can be extended (easily) via packages. There are about eight packages supplied with the R distribution and many more are available through the CRAN family of Internet sites covering a very wide range of modern statistics.\n\nR has its own LaTeX-like documentation format, which is used to supply comprehensive documentation, both on-line in a number of formats and in hardcopy.",
+    "url": "https://www.r-project.org/",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "visualization",
+      "machine learning",
+      "data science",
+      "graphics",
+      "statistics"
+    ],
+    "technologies": [
+      "c",
+      "javascript",
+      "c++",
+      "r-project",
+      "fortran"
+    ],
+    "contact_email": "gsoc-r@googlegroups.com",
+    "projects_url": "https://github.com/rstats-gsoc/gsoc2026/wiki/table-of-proposed-coding-projects"
+  },
+  {
+    "name": "Rizin",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/rizin/7ageygqfyv7wzlee-360.png",
+    "image_background_color": null,
+    "description": "The Rizin project is a fork of the famous Radare2 project that started in 2006. Since then the codebase has been rewritten multiple times, modularized and extended to support many new features. The Rizin project aims to provide stability, focus on the most important features, and provide a user friendly interface. Along with Cutter - a Qt-based GUI and the RzGhidra decompiler it makes the effective tool for everyday reversing tasks.\n\nRizin is composed of a hexadecimal editor at its core, with support for several architectures and binary formats. It features code analysis capabilities, scripting, data and code visualization through graphs and other means, a visual mode, easy UNIX integration, a binary diffing engine for code and data, a shellcode compiler, multi-platform debug with reverse debug capabilities and much, much more!",
+    "url": "https://rizin.re",
+    "category": "Security",
+    "topics": [
+      "reverse engineering",
+      "computer security",
+      "debugging",
+      "emulation",
+      "disassembly"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "go",
+      "c++",
+      "qt"
+    ],
+    "contact_email": "gsoc@rizin.re",
+    "projects_url": "https://rizin.re/gsoc/2026/#project-ideas"
+  },
+  {
+    "name": "rocket.chat",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/rocketchat/qnog9kebwa9atw3l-360.png",
+    "image_background_color": null,
+    "description": "Open source team chat and communications platform \n\nRocket.Chat is one of the largest active open source (permissive MIT license) nodeJS communications platform communities on GitHub, connecting 2,500+ global community contributors (across projects) from 30+ countries, with 41,700+ GitHub stars, 11,100 forks, 1,005+ total releases and 15,100+ issues since inception in 2015.\n\nRocket.Chat is a team chat platform written in full-stack Typescript. It offers a fully featured team chat experience on modern browsers, comparable to Slack and Microsoft Teams. Mobile and desktop clients run on iOS, Android, Mac, Windows, and Linux. The server can scale from a small family messaging server for 5 users on a Raspberry Pi 5, to clustered micro-services configuration that can support hundred thousands of users. On-premises Rocket.Chat can ensure 100% complete security and privacy of your valuable communications/data.\n\nRocket.Chat is now installed on over 500k servers and counts over 12m users worldwide.  Federated communication support extends our reach exponentially. \n\nUsers can set up Rocket.Chat on cloud or by hosting their own servers on-premises. Thanks to its extension support via Rocket.Chat Apps, and rich APIs, startups and innovators have customized Rocket.Chat into new products and services. Omnichannel extends reach to wherever user may be including WhatsApp, Instagram, Facebook Messenger and more.  Increasingly, innovators in Generative AI  and LLM app developers are launching their concepts on the Rocket.Chat platform to keep all data flows and communications 100% private and secure. \n\nRocket.Chat has won multiple prizes such as a 2016 Bossie Award for Best Open Source Application and first prize in the 2017 edition of All Things Open’s Startup Competition.\n\nRocket.Chat's community interacts 24 x 7 at the community Rocket.Chat server  https://open.rocket.chat  since  2015.",
+    "url": "https://github.com/RocketChat",
+    "category": "Social and communication, Artificial Intelligence",
+    "topics": [
+      "communications",
+      "messaging",
+      "group chat",
+      "Team Collaboration",
+      "Chat platform"
+    ],
+    "technologies": [
+      "javascript",
+      "typescript",
+      "node",
+      "LLM",
+      "generative ai"
+    ],
+    "contact_email": "gsoc+2026@rocket.chat",
+    "projects_url": "https://github.com/RocketChat/google-summer-of-code/blob/main/google-summer-of-code-2026.md#-project-ideas"
+  },
+  {
+    "name": "Rspamd",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/rspamd/d2hi7vv5bavik21s-360.png",
+    "image_background_color": null,
+    "description": "We are supporting and maintaining Rspamd: an Open Source email processing framework and spam filter.",
+    "url": "https://www.rspamd.com",
+    "category": "Security, Social and communication",
+    "topics": [
+      "email",
+      "spam filtering"
+    ],
+    "technologies": [
+      "c",
+      "lua",
+      "c++",
+      "rust",
+      "clickhouse"
+    ],
+    "contact_email": "",
+    "projects_url": "https://rspamd.com/gsoc2025_ideas.html"
+  },
+  {
+    "name": "RTEMS Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/rtems-project/mgzdqflwj84er5ml-360.png",
+    "image_background_color": null,
+    "description": "RTEMS (Real-Time Executive for Multiprocessor Systems) is a free real-time operating system (RTOS) designed for deeply embedded systems such as automobile electronics, robotic controllers, and on-board satellite instruments. \n\nRTEMS is free open source software that supports multi-processor systems for over a dozen CPU architectures and over 150 specific system boards. In addition, RTEMS is designed to support embedded applications with the most stringent real-time requirements while being compatible with open standards such as POSIX. RTEMS includes optional functional features such as TCP/IP and file systems while still offering minimum executable sizes under 20 KB in useful configurations.\n\nThe RTEMS Project is the collection of individuals, companies, universities, and research institutions that collectively maintain and enhance the RTEMS software base. As a community, we are proud to be popular in the space application software and experimental physics communities. RTEMS has been to Venus, circles Mars, is aboard Curiosity, is in the asteroid belt, is on its way to Jupiter, and is circling the sun. It is in use in many high energy physics research labs around the world. There are many RTEMS users who do not belong to the space or physics communities, but our small part in contributing to basic scientific knowledge makes us proud.",
+    "url": "https://www.rtems.org/",
+    "category": "Operating systems, Science and medicine",
+    "topics": [
+      "kernel",
+      "embedded",
+      "real-time",
+      "multicore",
+      "rtos"
+    ],
+    "technologies": [
+      "python",
+      "c/c++",
+      "assembly",
+      "posix"
+    ],
+    "contact_email": "",
+    "projects_url": "https://projects.rtems.org/gsoc/"
+  },
+  {
+    "name": "SageMath",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/sagemath/1tcj7svgwadc13cj-360.png",
+    "image_background_color": null,
+    "description": "Mathematicians, scientists, researchers, and students need a powerful tool for their work or study. SageMath is a freely available open-source mathematical software system bundling the functionality of many software libraries, exposing their features in a common interface and extending on top of this with its own powerful algorithms. By leveraging the flexibility and universality of the underlying Python interpreter, SageMath is able to accommodate for a vast range of their requirements.\n\nThe mission of SageMath is to create a viable open-source alternative to all major proprietary mathematical software systems.\n\nPython is the main programming language inside the SageMath library and also the language of choice for all interactions with the built-in objects and functions for expressing mathematical concepts and calculations. Besides a command-line and programming-library interface, its primary user interface is a dynamic self-hosted website. From the perspective of a user, the interface language is Python, but with a thin extension built directly on top of it.\n\nAlmost all areas of mathematics are represented in SageMath, at various levels of sophistication. This includes symbolic calculus, 2D and 3D graphics, polynomials, graph theory, group theory, abstract algebra, combinatorics, cryptography, elliptic curves and modular forms, numerical mathematics, linear algebra and matrix calculations (over various rings), support for parallel computing, and a powerful coercion framework to “mix” elements from different sets for calculations. SageMath’s features also expand into neighboring fields like Statistics and Physics.",
+    "url": "https://www.sagemath.org",
+    "category": "Science and medicine",
+    "topics": [
+      "mathematics",
+      "education",
+      "research"
+    ],
+    "technologies": [
+      "python",
+      "cython"
+    ],
+    "contact_email": "tcscrims@gmail.com",
+    "projects_url": "https://wiki.sagemath.org/GSoC/2026"
+  },
+  {
+    "name": "Scala Center",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/scala-center/0umytpqshifjeevx-360.png",
+    "image_background_color": null,
+    "description": "We are an independent not-for-profit center established at EPFL. Scala Center's Mission is to guide and support the Scala community, coordinate and develop open-source libraries and tools for the benefit of all Scala users, provide deep, and quality, educational materials for Scala.",
+    "url": "https://scala-lang.org/",
+    "category": "Programming languages",
+    "topics": [
+      "education",
+      "compilers",
+      "web",
+      "tooling",
+      "gpu"
+    ],
+    "technologies": [
+      "jvm",
+      "functional programming",
+      "scala",
+      "scala.js",
+      "scala native"
+    ],
+    "contact_email": "scala-gsoc@epfl.ch",
+    "projects_url": "https://github.com/scalacenter/GoogleSummerOfCode"
+  },
+  {
+    "name": "ScummVM",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/scummvm/bnok4srtehdy3fbj-360.png",
+    "image_background_color": null,
+    "description": "ScummVM is a game preservation project with a quickly growing code base since more than 20 years. Originally focused on 2D Point&Click adventure games, its scope widened in 2016 to RPG thanks to successful GSoC students and to 3D games in 2020 after the merge with its sister project, ResidualVM. The purpose is only to replace the game executable, not to enhance or replace the game assets.",
+    "url": "https://www.scummvm.org/",
+    "category": "End user applications, Media",
+    "topics": [
+      "games",
+      "game engines",
+      "software preservation",
+      "software archeology"
+    ],
+    "technologies": [
+      "python",
+      "opengl",
+      "c++",
+      "assembly",
+      "sdl"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.scummvm.org/gsoc-2026-ideas"
+  },
+  {
+    "name": "Society for Arts and Technology (SAT)",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/society-for-arts-and-technology-sat/pkgrduycyoh0wxmf-360.png",
+    "image_background_color": null,
+    "description": "The Society for Arts and Technology [SAT] is a non-profit organization recognized internationally for developing and creatively using immersive technologies, computer vision, embedded systems, and connectivity tools. Founded in 1996, its triple mission as a center for the arts, training and research, is to enable and host teleimmersive multisensorial experiences.\n\nSAT creates open-source tools for pose detection, orchestration, gestural control, interaction, tele-copresence, audio spatialization, haptic feedback, and immersive multisensory multimedia authoring.",
+    "url": "https://sat.qc.ca",
+    "category": "Media, Artificial Intelligence",
+    "topics": [
+      "computer vision",
+      "graphics",
+      "multimedia",
+      "Telepresence",
+      "digital arts"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "c++",
+      "qt",
+      "esp32"
+    ],
+    "contact_email": "",
+    "projects_url": "https://sat-mtl.gitlab.io/collaborations/google-summer-of-code/categories/ideas/"
+  },
+  {
+    "name": "Software and Computational Systems Lab at LMU Munich",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/software-and-computational-systems-lab-at-lmu-munich/kcrheiieoyvdm0r7-360.png",
+    "image_background_color": null,
+    "description": "The Software and Computational Systems Lab is a research group at LMU Munich,\none of the leading universities in Germany.\nWe focus on the development of new models and algorithms to efficiently analyze software systems\nand emphasize on tool implementations of the theoretical concepts.\nFor GSoC 2024, we propose ideas involving several aspects of software analysis,\nfrom implementing and benchmarking verification algorithms to incorporating backend logic solvers.\n\nHere is a selection of the open-source projects developed by our group:\n\n<ol>\n<li> <a href=\"https://cpachecker.sosy-lab.org\">CPAchecker</a> is an\naward-winning framework for formal verification of C programs.\nIt is written in Java and based on a highly modular architecture\nthat allows one to develop and combine a wide range of different analyses. \nCPAchecker has helped to find hundreds of bugs in the Linux kernel.<li>\n\n<li><a href=\"https://gitlab.com/sosy-lab/software/cpa-daemon\">CPA-Daemon</a> is a gRPC-based microservice that enables users to run CPAchecker in a  cloud setup, with a focus on ease of use and continuous verification.</li>\n\n<li><a href=\"https://github.com/sosy-lab/java-smt\">JavaSMT</a> is a common API layer for accessing various SMT solvers\nfrom Java programs without having to use solver-specific APIs and care about subtle details.\nIt supports the majority of common SMT solvers and is used by a wide range of projects.\n</li>\n<li><a href=\"https://gitlab.com/sosy-lab/software/paralleljbdd\">PJBDD</a> is a multi-threaded\nBinary Decision Diagram (BDD) library written in Java.\nIt supports concurrent computation, parallel operations, and automated resource management.</li>\n\n<li><a href=\"https://github.com/sosy-lab/benchexec\">BenchExec</a> is a benchmarking framework (written in Python)\nthat uses modern Linux features such as cgroups and namespaces\nto create benchmarking containers and measure their resource usage.</li>\n</ol>\n\nFor a more detailed description and some prospective GSoC topics,\nplease visit <a href=\"https://www.sosy-lab.org/gsoc/gsoc2024.php#ideas\">our webpage</a>.\nYou are also welcome to suggest your own ideas!",
+    "url": "https://www.sosy-lab.org/",
+    "category": "Programming languages, Development tools",
+    "topics": [
+      "cloud",
+      "software verification",
+      "benchmarking",
+      "program analysis",
+      "SAT & SMT solving"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "java",
+      "grpc",
+      "Quarkus"
+    ],
+    "contact_email": "info@sosy-lab.org",
+    "projects_url": "https://www.sosy-lab.org/gsoc/gsoc2025.php"
+  },
+  {
+    "name": "SQLancer",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/sqlancer/hzunjobwazuptdb6.png",
+    "image_background_color": null,
+    "description": "SQLancer is an automated testing tool that finds logic bugs in database systems (rather than in the databases themselves). Logic bugs are bugs that cause a database system to compute an incorrect result for a given query and a database on which the query is executed. To that end, SQLancer semi-randomly generates databases and queries, whose results are then automatically validated. SQLancer has found hundreds of bugs in database systems such as SQLite, MySQL, DuckDB, CockroachDB, and TiDB.",
+    "url": "https://www.sqlancer.com",
+    "category": "Data, Programming languages",
+    "topics": [
+      "fuzzing",
+      "Automated Testing",
+      "Logic bugs",
+      "Database systems"
+    ],
+    "technologies": [
+      "java",
+      "sql"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/sqlancer/sqlancer/wiki/GSoC-2025-Ideas"
+  },
+  {
+    "name": "St. Jude Children's Research Hospital",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/st-jude-childrens-research-hospital-ai/qnfe4pckkvrq5tfw-360.png",
+    "image_background_color": null,
+    "description": "St. Jude Children's Research Hospital is a non-profit research hospital dedicated to advancing cures and means of prevention for children with catastrophic diseases. With respect to Google Summer of Code, we're interested in building modern, open-source infrastructure upon which large-scale scientific analyses can be done (typically focused on bioinformatics or genomics specifically).",
+    "url": "https://stjude.org",
+    "category": "Science and medicine, Programming languages",
+    "topics": [
+      "programming languages",
+      "genomics",
+      "developer tools",
+      "cloud"
+    ],
+    "technologies": [
+      "python",
+      "rust",
+      "simd",
+      "WDL"
+    ],
+    "contact_email": "clay.mcleod@stjude.org",
+    "projects_url": "https://gist.github.com/claymcleod/ee8e62831a4975cba2032d888bb52080"
+  },
+  {
+    "name": "stdlib",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/stdlib/7ornclj6w5zz9fca-360.png",
+    "image_background_color": null,
+    "description": "stdlib is a standard library for JavaScript and Node.js with an emphasis on numerical and scientific computing applications. The project aims to provide functionality similar to NumPy and SciPy for use in JavaScript environments with special consideration for the unique constraints and opportunities afforded by the Web. stdlib is primarily written in JavaScript, C, and Fortran.",
+    "url": "https://stdlib.io",
+    "category": "Science and medicine, Data",
+    "topics": [
+      "mathematics",
+      "web",
+      "scientific computing",
+      "numerical computing",
+      "statistics"
+    ],
+    "technologies": [
+      "c",
+      "javascript",
+      "node.js",
+      "typescript",
+      "webassembly"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/stdlib-js/google-summer-of-code/blob/main/ideas.md"
+  },
+  {
+    "name": "Ste||ar group",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/stear-group/sebxbtinyakvrevb-360.png",
+    "image_background_color": null,
+    "description": "The STE||AR Group is an international team of researchers who understand that a new approach to parallel computation is needed.  Our work is crafted around the idea that we need to invent new ways to more efficiently use the resources that we have and use the knowledge that we gain to help guide the creation of the machines of tomorrow.  This organization aims to support, coordinate, and distribute research done in this area by creating a marketplace of ideas where concepts are debated and solutions are transparently developed.",
+    "url": "http://stellar-group.org/",
+    "category": "Science and medicine, Programming languages",
+    "topics": [
+      "library",
+      "optimization",
+      "parallel algorithms",
+      "hpx",
+      "application"
+    ],
+    "technologies": [
+      "c++",
+      "hpc"
+    ],
+    "contact_email": "https://mail.cct.lsu.edu/mailman/listinfo/hpx-users",
+    "projects_url": "https://github.com/STEllAR-GROUP/hpx/wiki/Google-Summer-of-Code-(GSoC)-2026#2026-hpx-project-ideas"
+  },
+  {
+    "name": "Stichting SU2",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/stichting-su2/vexbqtmew7yd92hp-360.png",
+    "image_background_color": null,
+    "description": "Computational analysis tools have revolutionized the way we design engineering systems as a society, but most established codes are proprietary, unavailable, or prohibitively expensive for many users. The SU2 Foundation will change this, making multiphysics analysis and design optimization software free and publicly available, in a single place, without restriction on who can contribute to its creation and development.\nThe SU2 Foundation is an educational and scientific not-for-profit that will bring together computational scientists and engineers through the SU2 Foundation platform. The SU2 Foundation develops, maintains, and supports a collection of C++ and Python-based software tools for performing Partial Differential Equation (PDE) analysis and solving PDE-constrained optimization problems. Through maintaining and improving the quality of software, documentation, and tutorials, and by growing the community of users and developers, the SU2 Foundation will ensure quality improvement of multiphysics software tools, accessible by everyone, for continued innovation in the engineering sciences.",
+    "url": "https://su2foundation.org",
+    "category": "Science and medicine, End user applications",
+    "topics": [
+      "aerodynamics",
+      "Computational Fluid Dynamics",
+      "Multi-Disciplinary Optimization",
+      "Adjoint Design Optimization",
+      "Fluid Dynamics"
+    ],
+    "technologies": [
+      "python",
+      "c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://su2code.github.io/gsoc/Introduction/"
+  },
+  {
+    "name": "Sugar Labs",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/sugar-labs/pgbt7fp6gr6lhihd-360.png",
+    "image_background_color": null,
+    "description": "Sugar is an activity-focused, free/libre open-source software (FLOSS) learning platform for children. Collaboration, reflection, and discovery are integrated directly into the user interface. Through Sugar's clarity of design, children and teachers have the opportunity to use computers on their own terms. Students can reshape, reinvent, and reapply both software and content into powerful learning activities. Sugar's focus on sharing, constructive criticism, and exploration is grounded in the culture of free software and the ideals of learn-by-doing \"Constructionism\".",
+    "url": "https://sugarlabs.org",
+    "category": "End user applications, Programming languages",
+    "topics": [
+      "education",
+      "programming languages",
+      "games",
+      "desktop",
+      "generative AI"
+    ],
+    "technologies": [
+      "python",
+      "gtk",
+      "typescript",
+      "javascipt",
+      "LLM"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/sugarlabs/GSoC/blob/master/Ideas-2026.md"
+  },
+  {
+    "name": "SW360",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/sw360/scylub8cx6f9mkzk-360.png",
+    "image_background_color": null,
+    "description": "SW360 is an open source software project licensed under the EPL-2.0 that provides both a web application and a repository to collect, organize and make available information about software components. It establishes a central hub for software components in an organization.",
+    "url": "https://eclipse.dev/sw360/",
+    "category": "Web, Security",
+    "topics": [
+      "license compliance",
+      "compliance automation",
+      "SBOM",
+      "component repository",
+      "vulnerabilities management"
+    ],
+    "technologies": [
+      "java",
+      "react",
+      "couchdb",
+      "SpringBoot"
+    ],
+    "contact_email": "",
+    "projects_url": "https://eclipse.dev/sw360/gsoc/gsoc-projects-2026/"
+  },
+  {
+    "name": "Swift",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/swift/moutmu5fv3rozvrz-360.png",
+    "image_background_color": null,
+    "description": "Swift is a general-purpose programming language built using a modern approach to safety, performance, and software design patterns.\n\nThe goal of the Swift project is to create the best available language for uses ranging from systems programming, to mobile and desktop apps, scaling up to cloud services. Most importantly, Swift is designed to make writing and maintaining correct programs easier for the developer.",
+    "url": "https://swift.org",
+    "category": "Programming languages",
+    "topics": [
+      "compilers",
+      "cross-platform",
+      "Packages",
+      "Server development",
+      "Standard Libraries"
+    ],
+    "technologies": [
+      "c++",
+      "cmake",
+      "swift"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.swift.org/gsoc2026/"
+  },
+  {
+    "name": "SymPy",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/sympy/iz2tcxocrknp1sm0-360.png",
+    "image_background_color": null,
+    "description": "SymPy is a Python library for symbolic mathematics. It aims to become a full-featured computer algebra system (CAS) while keeping the code as simple as possible in order to be comprehensible and easily extensible. SymPy is written entirely in Python.",
+    "url": "https://www.sympy.org/",
+    "category": "Science and medicine",
+    "topics": [
+      "mathematics",
+      "physics",
+      "symbolic mathematics"
+    ],
+    "technologies": [
+      "python",
+      "numpy",
+      "jupyter"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/sympy/sympy/wiki/GSoC-Ideas"
+  },
+  {
+    "name": "Synfig",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/synfig/ohcj3eigerib4jym-360.png",
+    "image_background_color": null,
+    "description": "Synfig is a 2D open-source animation software. It is capable to produce vector artwork and also can work with bitmap images.\n\nThe main concept of Synfig is \"tweening\" - you can define object positions or shapes of vector objects at certain points of time and program will interpolate in-between frames automatically. You can also use bones to control your animation on higher level.\n\nWith Synfig you can easily create motion graphics and cut-out animations for product explanation videos, tutorial videos, and more.",
+    "url": "https://synfig.org",
+    "category": "Media",
+    "topics": [
+      "2d/3d graphics",
+      "animation",
+      "vector graphics"
+    ],
+    "technologies": [
+      "python",
+      "c++",
+      "gtk",
+      "gtkmm"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/synfig/synfig-docs-dev/blob/master/docs/gsoc/2026/ideas.rst"
+  },
+  {
+    "name": "TARDIS RT Collaboration",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/tardis-rt-collaboration/0ocxr3jw3fwdloye-360.png",
+    "image_background_color": null,
+    "description": "TARDIS is a tool that creates synthetic observations (spectra) for exploding stars (supernovae). \n\nA supernova marks the brilliant death throes of a star, during which it outshines its entire galaxy. Through their explosive stellar death, supernovae enrich the Universe with new elements necessary for the formation of planets and life as we know it. From the iron in your blood to the silicon in your laptop, supernovae are responsible for producing many important elements from the primordial hydrogen and helium left over from the Big Bang.\n\nTARDIS provides a link between theory and observations: by creating synthetic spectra from theoretical assumptions and comparing these to observations, we can both interpret data and test models for why, when and how supernova explosions occur.\nWe, the community around TARDIS, are interested in combining astronomy, computer science, statistics and modern software design to build a tool that is useful both in research and teaching alike (with supporting documentation that would, in theory, allow anyone to recreate the project from scratch). Please join us on https://gitter.im/tardis-sn/gsoc.",
+    "url": "https://tardis-sn.github.io",
+    "category": "Science and medicine",
+    "topics": [
+      "visualization",
+      "big data",
+      "simulation",
+      "astrophysics"
+    ],
+    "technologies": [
+      "python",
+      "numba",
+      "numpy",
+      "jupyter",
+      "pandas"
+    ],
+    "contact_email": "",
+    "projects_url": "https://tardis-sn.github.io/summer_of_code/ideas/"
+  },
+  {
+    "name": "The FreeBSD Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-freebsd-project/4jmspor6mcto9wti-360.png",
+    "image_background_color": null,
+    "description": "FreeBSD is an operating system renowned for its advanced networking capabilities, robust security features, and exceptional performance. It is used across a wide spectrum of computing environments, ranging from the most heavily trafficked websites to desktop computers and embedded devices. Our source code is the foundation for well-known products such as the Sony PlayStation, Junos (the operating system powering Juniper routers), and elements of Apple's macOS. Additionally, FreeBSD runs on servers at Netflix that stream terabits of video content every second.\n\nThe FreeBSD Project has a rich history spanning over 30 years, originating in 1993 but rooted in work from the Berkeley Computer Systems Research Group dating back to 1978.  Over the years, our codebase has undergone continuous development and played an important role in developing essential software components used by numerous open-source projects. Examples include bsnmp, jemalloc, libarchive, and OpenPAM.\n\nFreeBSD maintains an active mentoring program to welcome new developers into our vibrant community. With approximately 300 developers with write access to our repositories and numerous other contributors, our community thrives on collaboration and shared expertise. Many of our past Google Summer of Code contributors have transitioned into becoming key members of the FreeBSD development team.\n\nCommunication within the FreeBSD community occurs through various channels, including mailing lists, forums, blogs, IRC channels, and user groups, all listed on our main website.",
+    "url": "https://www.freebsd.org/",
+    "category": "Operating systems",
+    "topics": [
+      "virtualization",
+      "operating system",
+      "Embedded System"
+    ],
+    "technologies": [
+      "c",
+      "llvm",
+      "assembly",
+      "make",
+      "POSIX shell"
+    ],
+    "contact_email": "soc-admins@FreeBSD.org",
+    "projects_url": "https://wiki.freebsd.org/SummerOfCodeIdeas"
+  },
+  {
+    "name": "The Honeynet Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-honeynet-project/pvycoc21p2ketj7b-360.png",
+    "image_background_color": null,
+    "description": "The Honeynet Project is a leading international 501c3 non-profit security research organization, dedicated to investigating the latest attacks and developing open source security tools to improve Internet security. With Chapters around the world, our volunteers have contributed to fight against malware (such as Conficker), discovering new attacks and creating security tools used by businesses and government agencies all over the world.\n\nThe Honeynet Project uses GSoC as a incubator for new R&D projects, and to recruit active new members.",
+    "url": "https://honeynet.org",
+    "category": "Security",
+    "topics": [
+      "honeypots",
+      "malware analysis",
+      "Threat Intelligence"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "django",
+      "go",
+      "docker"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.honeynet.org/gsoc/gsoc-2026/google-summer-of-code-2026-project-ideas/"
+  },
+  {
+    "name": "The JPF team",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-jpf-team-hg/rvqtnz4hyojrfgvw.png",
+    "image_background_color": null,
+    "description": "The Java Pathfinder (JPF) project was initially conceived and developed at NASA Ames Research Center in 1999. JPF was open sourced in April 2005 as one of the first ongoing NASA development projects to date, and it is now released under the Apache license, 2.0. JPF is an extensible Java virtual machine written in Java itself. It is used to create a variety of verification and debugging tools, ranging from software model checkers to test case generators using symbolic execution. JPF is a research platform and a production tool at the same time. Although JPF has major contributions from companies and government agencies, our main user community is academic - there are ongoing collaborations with more than 20 universities worldwide. The JPF team for GSoC 2024 includes researchers from NASA Ames Research Center, KTH Royal Institute of Technology - Sweden, Carnegie Mellon University, Boise State University, University of Minnesota, Charles University - Czech Republic, and Singapore University of Technology and Design.\n\nJPF is designed to be highly extensible. There are well-defined extension mechanisms, directory structures and build procedures, which keep the core relatively stable and provide suitable, well-separated testbeds for new ideas and alternative implementations. As a consequence, we host a number of such extension projects on our own, public JPF server, together with a Wiki that provides a central location for learning about, obtaining, and contributing to JPF.\n\nJPF has been used for a variety of application domains and research topics such as verification of multi-threaded applications, graphical user interfaces, networking, and distributed applications. In addition to its continued presence in academia, JPF has matured enough to support verification of production code and frameworks such as Android. JPF is constantly being extended with support for verification of new types of correctness properties and for new types of application domains.",
+    "url": "https://github.com/javapathfinder/jpf-core/wiki",
+    "category": "Programming languages, Security",
+    "topics": [
+      "model checking",
+      "symbolic execution",
+      "verification of concurrent systems",
+      "program analysis",
+      "test input generation"
+    ],
+    "technologies": [
+      "android",
+      "java",
+      "distributed systems",
+      "jvm"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/javapathfinder/jpf-core/wiki/GSoC-2026-Project-Ideas"
+  },
+  {
+    "name": "The Julia Language",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-julia-language/49fck3n7j5aqnpwu-360.png",
+    "image_background_color": null,
+    "description": "The Julia Language is an open-source, high level, and dynamic language built to be easy to use like Python while having speed near C++. As an umbrella organization, we house projects related to core Julia (the language) as well as packages from the broader Julia ecosystem.",
+    "url": "https://julialang.org",
+    "category": "Science and medicine, Programming languages",
+    "topics": [
+      "math",
+      "artificial intelligence",
+      "science",
+      "data science",
+      "graphs"
+    ],
+    "technologies": [
+      "machine learning",
+      "julia",
+      "data science",
+      "compilers",
+      "garbage-collection"
+    ],
+    "contact_email": "",
+    "projects_url": "https://julialang.org/jsoc/projects/"
+  },
+  {
+    "name": "The Linux Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-linux-foundation/ydeu9rliawhe6of9-360.png",
+    "image_background_color": null,
+    "description": "The Linux Foundation is a non-profit consortium dedicated to fostering the growth of Linux. Founded in 2007 as a merger of the former Free Standards Group (FSG) and the former Open Source Developer Lab (OSDL), the LF sponsors the work of Linux creator Linus Torvalds and is supported by leading Linux and open source companies and developers from around the world. The Linux Foundation promotes, protects and standardizes Linux by providing unified resources and services needed for open source to successfully compete with closed platforms. For more see our [About page](https://www.linuxfoundation.org/about/). All software produced by us is free software published under OSI-approved licenses. See project ideas page for the license used by each project.",
+    "url": "http://www.linuxfoundation.org/",
+    "category": "Operating systems",
+    "topics": [
+      "kernel",
+      "automotive",
+      "printing",
+      "iio",
+      "zephyr"
+    ],
+    "technologies": [
+      "c",
+      "linux",
+      "cups",
+      "ai",
+      "fuzz-testing"
+    ],
+    "contact_email": "till@linux.com",
+    "projects_url": "https://github.com/LinuxFoundationGSoC/ProjectIdeas/wiki/Google-Summer-of-Code-2026"
+  },
+  {
+    "name": "The Mifos Initiative",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-mifos-initiative/etmiqn0lkvfxvm5p-360.png",
+    "image_background_color": null,
+    "description": "We are a global 501(c)3 fintech non-profit leveraging the cloud, mobile & open source community to democratize financial services worldwide and digitally transform the world’s 3 billion poor and underbanked. Mifos has pioneered open source banking technology for the past fifteen years transforming the entire sector at each major stage of evolution from microfinance to financial inclusion to digital financial services and now embedded finance. Mifos guides the open source community, steers the roadmap, and stewards the vibrant ecosystem of organizations building solutions on its open platform. Our building blocks for banking, recognized as digital public goods, make core banking commoditized infrastructure, empowering any organization, anywhere to embed any financial service to any customer via any channel. These building blocks provide the common functionalities for creating customers, managing wallets, savings and loan accounts, orchestrating payments, and  maintaining the financial ledger & reports. More than 65 million clients are reached by 500+ financial institutions across 70 countries using solutions powered by our APIs.",
+    "url": "https://mifos.org",
+    "category": "End user applications, Artificial Intelligence",
+    "topics": [
+      "artificial intelligence",
+      "cloud",
+      "fintech",
+      "financial inclusion",
+      "mobile banking"
+    ],
+    "technologies": [
+      "android",
+      "java",
+      "kotlin",
+      "spring",
+      "angular"
+    ],
+    "contact_email": "info@mifos.org",
+    "projects_url": "https://mifosforge.jira.com/wiki/spaces/RES/pages/5021990914/2026+Google+Summer+of+Code+Ideas+List"
+  },
+  {
+    "name": "The NetBSD Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-netbsd-foundation/gi3vozsqpecopqku-360.png",
+    "image_background_color": null,
+    "description": "NetBSD is a free, fast, secure, and highly portable Unix-like Open Source operating system. It is available for a wide range of platforms, from large-scale servers and powerful desktop systems to handheld and embedded devices. Its clean design and advanced features make it excellent for use in both production and research environments, and the source code is freely available under a business-friendly license. NetBSD is developed and supported by a large and vivid international community. Many applications are readily available through pkgsrc, the NetBSD Packages Collection.",
+    "url": "https://www.NetBSD.org/",
+    "category": "Operating systems, Programming languages",
+    "topics": [
+      "kernel",
+      "packaging",
+      "userland",
+      "unix",
+      "bsd"
+    ],
+    "technologies": [
+      "c",
+      "shell script",
+      "make",
+      "unix",
+      "bsd"
+    ],
+    "contact_email": "",
+    "projects_url": "https://wiki.NetBSD.org/projects/gsoc/"
+  },
+  {
+    "name": "The ns-3 Network Simulator Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-ns-3-network-simulator-project/0zmaec44y4jcfuj2-360.png",
+    "image_background_color": null,
+    "description": "Are you interested in contributing to a widely-used performance evaluation tool for computer networking research? ns-3 is a *discrete-event, packet-level network simulator* with an emphasis on networking research and education. Users of ns-3 can construct simulations of computer networks using models of traffic generators, protocols such as TCP/IP, and devices and channels such as Wi-Fi and LTE, and analyze or visualize the results. Simulation plays a vital role in the research and education process, because of the ability for simulations to obtain reproducible results (particularly for wireless protocol design), scale to large networks, and study systems that have not yet been implemented. A particular emphasis in ns-3 is a high degree of realism in the models (including frameworks for using real application and kernel code) and integration of the tool with virtual machine environments and testbeds. Very large scale simulations are possible; simulations of hundreds of millions of nodes have been published.  ns-3 has been in development since 2005 and has been making regular releases since June 2008.  The simulator is written in C++, with bindings for Python scripting, and uses the CMake build system.  We use a GPLv2 licensing model and heavily use mailing lists and Zulip chat, but typically not other social media.",
+    "url": "https://www.nsnam.org",
+    "category": "Science and medicine",
+    "topics": [
+      "computer networking",
+      "network simulation"
+    ],
+    "technologies": [
+      "python",
+      "django",
+      "c++"
+    ],
+    "contact_email": "",
+    "projects_url": "https://www.nsnam.org/wiki/GSOC2026Projects"
+  },
+  {
+    "name": "The P4 Language Consortium",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-p4-language-consortium/tru8mncy4zqlbxhe.png",
+    "image_background_color": null,
+    "description": "Programming Protocol-independent Packet Processors (P4) is a domain-specific language for network devices, specifying how data plane devices (switches, NICs, routers, filters, etc.) process packets.\n\nBefore P4, vendors had total control over the functionality supported in the network. And since networking silicon determined much of the possible behavior, silicon vendors controlled the rollout of new features (e.g., VXLAN), and rollouts took years.\n\nP4 turns the traditional model on its head. Application developers and network engineers can now use P4 to implement specific behavior in the network, and changes can be made in minutes instead of years.",
+    "url": "https://p4.org/",
+    "category": "Programming languages, Infrastructure and cloud",
+    "topics": [
+      "networking",
+      "programming language",
+      "compiler",
+      "AI/ML Networking",
+      "networking security"
+    ],
+    "technologies": [
+      "llvm",
+      "c++",
+      "linux kernel",
+      "mlir",
+      "ebpf"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/p4lang/gsoc/blob/main/2026/ideas_list.md"
+  },
+  {
+    "name": "The Palisadoes Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-palisadoes-foundation/r6rilsadbxyujakk-360.png",
+    "image_background_color": null,
+    "description": "The Palisadoes Foundation’s open-source software projects support community groups in organizing their daily activities. A significant proportion of our software contributions come from university students studying software engineering. Participants often come from under-served communities or geographic areas and are sponsored through our various programs. This prepares them for the competitive realities of the working world.\n\nLife started for us in 2016 when a group of expatriate Jamaicans wanted to assist development of new and existing information technologies for the island’s social good.  We knew academic and student leadership wanted greater practical exposure to the latest technology. In response, our pilot Calico program for Jamaican universities was created with the goal of addressing the issues graduates would face when employed.\n\nAfter five years of success, members of the Jamaican diaspora suggested we expand our service area to be global. They saw similar needs in their own under-served communities where the digital divide is very visible and thought our experience in the developing world would be useful.\n\nSince 2019 we have focused on creating a mobile app to help community organizations like ourselves better manage their membership. We saw the need for a social media component to keep in contact with our volunteers. We also felt these organizations often faced challenges with the project management of events and keeping track of volunteer abilities, roles, and responsibilities.\n\nWe want to make the app useful for any community-based organization such as clubs, small religious institutions, neighborhood groups, and volunteer associations. We also want to see how the open-source software could be installed as a multi-tenant, multi-site cloud hosted service as many of these organizations often don’t have sufficient IT skills to do so independently. We hope that our contributors will help us achieve this goal.",
+    "url": "https://www.palisadoes.org",
+    "category": "Social and communication, Artificial Intelligence",
+    "topics": [
+      "web",
+      "api",
+      "networking",
+      "ai",
+      "mobile"
+    ],
+    "technologies": [
+      "python",
+      "postgresql",
+      "flutter",
+      "graphql",
+      "typescript"
+    ],
+    "contact_email": "",
+    "projects_url": "https://developer.palisadoes.org/docs/internships/gsoc/gsoc-ideas"
+  },
+  {
+    "name": "The Rust Foundation",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-rust-foundation/pplrhxvka7dufvsn.png",
+    "image_background_color": null,
+    "description": "The Rust Project is a group of developers and maintainers who build and support the Rust programming language. Organised into teams, they develop new features and mantain the Rust language, its compiler and standard library, and also all kinds of infrastructure that supports Rust. This application is being made by the Rust Foundation, the legal entity for the Rust Programming language, working in close association with representatives from the Rust Project.",
+    "url": "https://www.rust-lang.org",
+    "category": "Programming languages",
+    "topics": [
+      "compilers",
+      "programming languages"
+    ],
+    "technologies": [
+      "python",
+      "rust"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/rust-lang/google-summer-of-code"
+  },
+  {
+    "name": "The Tor Project",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/the-tor-project/1w40vc9lqddvbfoa-360.png",
+    "image_background_color": null,
+    "description": "We believe everyone should be able to explore the internet with privacy. We are the Tor Project, a 501(c)(3) US nonprofit. We advance human rights and defend your privacy online through free software and open networks.",
+    "url": "https://www.torproject.org/",
+    "category": "Web, Security",
+    "topics": [
+      "security",
+      "privacy",
+      "anti-censorship",
+      "Human Rights",
+      "Surveillance"
+    ],
+    "technologies": [
+      "c",
+      "python",
+      "web",
+      "rust"
+    ],
+    "contact_email": "gsoc@torproject.org",
+    "projects_url": "https://gitlab.torproject.org/tpo/team/-/wikis/GSoC"
+  },
+  {
+    "name": "Typelevel",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/typelevel/hxlcctbqekguxcxx.png",
+    "image_background_color": null,
+    "description": "Typelevel is an ecosystem of projects and a community of people united to foster an inclusive, welcoming, and safe environment around functional programming in Scala. We work together to develop projects that apply functional programming to challenging problems relevant in industry. Our community culture embraces curiosity and mentoring and we don't shy away from experimenting with new and exciting ideas. Most of all, we love to make programming joyful and social.",
+    "url": "https://typelevel.org",
+    "category": "Programming languages, Web",
+    "topics": [
+      "web",
+      "functional programming",
+      "cloud",
+      "AI/ML",
+      "cats"
+    ],
+    "technologies": [
+      "linux",
+      "node.js",
+      "jvm",
+      "scala",
+      "wasm"
+    ],
+    "contact_email": "gsoc@typelevel.org",
+    "projects_url": "https://typelevel.org/gsoc/ideas.html"
+  },
+  {
+    "name": "UC OSPO",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/center-for-research-in-open-source-software-cross/ndbkr7fqcqp4nguq-360.png",
+    "image_background_color": null,
+    "description": "The UCSC Open Source Program Office (OSPO) and the UC OSPO Network supports open source work throughout the University of California system. Beginning in 2022, the UCSC OSPO took over the programmatic responsibilities of the UCSC Center for Research in Open Source Software (CROSS), including mentorship activities such as GSoC. The UCSC OSPO creates partnerships with stakeholders within and outside the UC system in order to help students learn from open source communities, support scientists in using open source to accelerate research efforts, and connect students and scientists with sponsors from industry, government, and foundations. The OSPO helps bridge the gap between academic research and successful open source projects by promoting innovative projects maintained by UC-affiliated scientists and researchers. We support the transfer of cutting-edge technology resulting from UC-originating research to industry via successful open source projects. Due to the multi-campus nature of our current efforts, the projects we support and promote cover a wide range of topics and technologies - including:\n\n- Open Source Hardware and Chip Design\n- AI / Machine Learning\n- Storage Systems and Devices\n- Data Science and visualization\n- Scientific Computing & Research Infrastructure\n- Reproducibility\n- Cloud-based computation\nAll of our mentors are scientists and researchers who are actively involved in one or more of these open source projects.",
+    "url": "https://ucsc-ospo.github.io/osre26/",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "education",
+      "bioinformatics",
+      "data science",
+      "AI/ML",
+      "research software"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "c/c++",
+      "machine learning",
+      "pytorch"
+    ],
+    "contact_email": "ospo-info-group@ucsc.edu",
+    "projects_url": "https://ucsc-ospo.github.io/osre26/#projects"
+  },
+  {
+    "name": "Unicode, Inc.",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/unicode-inc/cev3zg8tjatag4mt.png",
+    "image_background_color": null,
+    "description": "The Unicode Consortium is the non-profit open source, open standards body for the internationalization of software and services. Deployed on more than 20 billion devices around the world, Unicode also provides the solution for internationalization and the architecture to support localization.",
+    "url": "https://home.unicode.org",
+    "category": "Programming languages, Other",
+    "topics": [
+      "compilers",
+      "linguistics",
+      "languages",
+      "internationalization"
+    ],
+    "technologies": [
+      "java",
+      "c++",
+      "rust",
+      "unicode"
+    ],
+    "contact_email": "GSOC@unicode.org",
+    "projects_url": "https://docs.google.com/document/d/e/2PACX-1vSNa7tZh-MHWc1rcxJKL-7D6-1PtHuLduGIBKLg8KyFJlWH3ky0U1oY0R0sIpvIG2cAFKOHE3TdBPM6/pub"
+  },
+  {
+    "name": "Unikraft",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/unikraft/5nx7anuq3iixdm54.png",
+    "image_background_color": null,
+    "description": "Unikraft is a fast, secure and open-source Unikernel Development Kit.\n\nBy tailoring the operating system, libraries and configuration to the particular needs of your application, it vastly reduces virtual machine and container image sizes to a few KBs, provides blazing performance, and drastically cuts down your software stack’s attack surface.\n\nUnikraft is developed in the spirit of open source: public discussions on Discord, open source licensing model using BSD-3-Clause, public development and management on GitHub.\n\nIt does so in the context of a vibrant community consisting of highly skilled software engineers, researchers, teachers, students and hobbyists. Periodic meetings, hackathons and a consistent presence in open source events are central to the well functioning of the community.\n\nWe use guidelines for development and maintenance to ensure the creation of high quality code.\n\nPublic releases are planned to happen once every two months. In general, we aim for a public release to happen at the last Monday of each odd month (January, March, May, etc.)\n\nWe welcome contributors and users on Discord and on GitHub. If you are looking for a fun technical project in the area of operating systems, virtualization, come aboard on Discord.",
+    "url": "https://unikraft.org/",
+    "category": "Operating systems, Infrastructure and cloud",
+    "topics": [
+      "virtualization",
+      "cloud",
+      "software reuse",
+      "software configurability"
+    ],
+    "technologies": [
+      "c",
+      "xen",
+      "golang",
+      "kvm",
+      "assembly language"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/unikraft/gsoc/blob/staging/gsoc-2026/ideas.md"
+  },
+  {
+    "name": "Uramaki LAB",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/uramaki-lab/pr3ivuk0zg7lhgj1-360.png",
+    "image_background_color": null,
+    "description": "The RUXAILAB is an open-source organization dedicated to democratizing usability and accessibility evaluation through the use of Artificial Intelligence. We provide a suite of AI-powered tools that enable remote usability and accessibility testing, ensuring that professionals and researchers can analyze user experience through different methodologies.\n\nOur platform supports multiple methods such as User Testing, Heuristic Evaluation, Eye-Tracking system, Sentimental Analysis, a semi-automated tool for prototyping virtual reality environments in 2D, and heatmap analysis for advanced data extraction. \n\nOur mission is to eliminate financial and technological barriers to usability and accessibility research, making it possible for anyone, anywhere to set up their own usability lab at zero cost.\n\nWe invite developers, designers, and researchers to join us in expanding our toolkit, refining our existing solutions, and fostering a more accessible digital world. 🚀🌍",
+    "url": "https://github.com/ruxailab",
+    "category": "End user applications, Artificial Intelligence",
+    "topics": [
+      "artificial intelligence",
+      "user experience",
+      "Usability",
+      "Eye Tracking"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "html",
+      "css",
+      "Firebase"
+    ],
+    "contact_email": "ruxailab@gmail.com",
+    "projects_url": "https://ruxailab.github.io/gsoc/"
+  },
+  {
+    "name": "VideoLAN",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/videolan/9h28hsncvrt01voz-360.png",
+    "image_background_color": null,
+    "description": "The VideoLAN project is led by and composed of a team of volunteers who believe in the power of open source to rock the multimedia world. We produce multimedia software notably the famous VLC media player as well as designated libraries and codecs.",
+    "url": "https://www.videolan.org",
+    "category": "End user applications, Media",
+    "topics": [
+      "audio",
+      "streaming",
+      "video",
+      "codecs",
+      "media database"
+    ],
+    "technologies": [
+      "c",
+      "c++",
+      "qt",
+      "assembly",
+      "video"
+    ],
+    "contact_email": "videolan@videolan.org",
+    "projects_url": "https://wiki.videolan.org/SoC_2026/"
+  },
+  {
+    "name": "Wagtail",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/wagtail/so6hnqeqh2cp4jbx-360.png",
+    "image_background_color": null,
+    "description": "We build Wagtail, a popular content management system. It's built on Python, by an active and engaged open source community, which has grown rapidly since Wagtail's release in 2014. Wagtail is available in over 40 languages, and used by some of the world's best-known organizations, including NASA, Google, Mozilla, MIT, and the UK's National Health Service, as well as museums, universities, non-profits, governments, banks, studios, restaurants, startups and bloggers around the world.",
+    "url": "https://wagtail.org/",
+    "category": "Web",
+    "topics": [
+      "web",
+      "accessibility",
+      "cms"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "django"
+    ],
+    "contact_email": "",
+    "projects_url": "https://github.com/wagtail/gsoc/blob/main/project-ideas.md"
+  },
+  {
+    "name": "Waycrate",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/waycrate/u6pnvceiilur7iqy-360.png",
+    "image_background_color": null,
+    "description": "Waycrate creates powerful and simple open source applications and libraries to ease the adoption of the Wayland protocol.",
+    "url": "https://waycrate.github.io/",
+    "category": "End user applications, Development tools",
+    "topics": [
+      "security",
+      "graphics",
+      "Wayland",
+      "ScreenCapture",
+      "Desktop Portals"
+    ],
+    "technologies": [
+      "c",
+      "c++",
+      "rust",
+      "wayland",
+      "Zig"
+    ],
+    "contact_email": "waycrate@gmail.com",
+    "projects_url": "https://waycrate.github.io/outreach/gsoc/2025/idea-list/"
+  },
+  {
+    "name": "webpack",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/webpack/bb5phgrkm0y4op3e-360.png",
+    "image_background_color": null,
+    "description": "webpack is THE build tool for modern web applications run on NodeJS\nwebpack is a module bundler. Its main purpose is to bundle JavaScript files for usage in a browser, yet it is also capable of transforming, bundling, or packaging just about any resource or asset.\n\nOverview\nCurrently in the web, modules are not fully adopted, and therefore we need tooling to help compile your module code into something that will work in the browser. webpack champions this by not only supporting CommonJS, AMD, RequireJS module systems, but also ECMAScript Modules (ESM).\n\nWhat makes webpack unique?\nExtensibility webpack is built using an extensible event-driven architecture. This means that a majority of our code is Plugins that hook into a set of lifecycle events. This means that it is infinitely flexible and configurable. This architecture also lets us pivot very quickly. Plugins isolate functionality (and can even be used in your configuration), and allow us to add and drop new functionality without breaking the rest of the system.\n\nFocused around Web Performance webpack revived a classic technique from Google Web Toolkit known as \"code splitting\". Code splitting let's developers write imperative instructions (as a part of their code), to split up their JavaScript bundles (at build time) into multiple pieces that can be loaded lazily.\n\nBuilt in JavaScript webpack's configuration format, and architecture is all built and run on NodeJS. This means that anyone comfortable with JavaScript can break open our source code with a low level of entry to learn, contribute to, and improve.\n\nUsed at Scale webpack is used by companies like AirBnB, Microsoft, Housing.com, Flipkart, Alibaba, to build high performance, scaled web applications.\n\nCommunity Owned webpack is not backed by a single organization, rather by its users, contributors, backers, sponsors, and shareholders. This means that every decision we make is for them, and them only.",
+    "url": "https://webpack.js.org",
+    "category": "Web, Development tools",
+    "topics": [
+      "web development",
+      "javascript",
+      "webassembly",
+      "Node.js",
+      "webpack"
+    ],
+    "technologies": [
+      "javascript",
+      "typescript",
+      "node"
+    ],
+    "contact_email": "evenstensberg@gmail.com",
+    "projects_url": "https://docs.google.com/document/d/1Mr_IPVdbupGwmGtcvLlVqFEL8wYN_rlfHUghJ2EPBVE/edit?usp=sharing"
+  },
+  {
+    "name": "Wellcome Sanger Tree of Life",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/wellcome-sanger-institute/gmcjtlourmhkhhed-360.png",
+    "image_background_color": null,
+    "description": "Two scientific units of the Sanger Institute are focusing their effort on non-human genomics, encompassing all organisms on Earth. The Tree of Life programme is generating high-quality reference genome assemblies for thousands of species, and releasing them to the community to help decipher genome function and organisation, and improve our understanding of biodiversity. Novel software and methods are required for the processing of this vast amount of data. The Genomic Surveillance Unit improves global human health by accelerating the use and impact of genomic surveillance, for instance to fight malaria. It delivers products, tools, and services that empower public health partners to add genomic information to decision-making.",
+    "url": "https://www.sanger.ac.uk/",
+    "category": "Science and medicine, Artificial Intelligence",
+    "topics": [
+      "machine learning",
+      "genomics",
+      "bioinformatics",
+      "genome analysis"
+    ],
+    "technologies": [
+      "python",
+      "machine learning",
+      "natural language processing",
+      "nextflow",
+      "Cloud Storage"
+    ],
+    "contact_email": "gsoc@sanger.ac.uk",
+    "projects_url": "https://docs.google.com/document/d/1dRHwnHAXlwQbRDstnd0OZTDJYA9cTsl1jG_hOempqII/edit?usp=sharing"
+  },
+  {
+    "name": "Zendalona",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/zendalona/tqduj6nsxnnw3vpy-360.png",
+    "image_background_color": null,
+    "description": "Zendalona is an organization providing accessibility solutions for visually impaired.\n\nIn 2020, the WHO reported a significant global challenge: an estimated 2.2% of the world's population suffered from moderate to severe distance vision impairments, with 0.39% experiencing total blindness. These individuals often rely on the assistance of others for their daily needs, especially in developing nations where government resources are limited for their well-being, education, and overall quality of life. \n\nAt Zendolona has  embraced a noble mission – to make a meaningful difference in the lives of those facing these challenges. We are committed to achieve this by leveraging expertise in developing innovative systems, tools, and techniques. predominantly within the realm of software solutions. Our multi-faceted approach includes: \n\n1 Customization of Existing Tools: Zendalona adapts and tailors existing software tools to cater specifically to the needs of the visually impaired, bridging accessibility gaps and enhancing their quality of life. This is also extend to deafblind. \n\n2 Development of New Tools: Zendolona takes pride in pioneering new technologies and solutions designed to empower the visually impaired, as well as individuals who may face multiple sensory impairments, such as deafness and speech impediments. \n\n3 Education and Training: With a team boasting decades of experience in teaching and mentoring, Zendalona is dedicated to provide comprehensive training and support to visually impaired children and adults, ensuring they have the skills and knowledge to lead independent and fulfilling lives. \n\nOur commitment extends beyond philanthropy; it's driven by a deep-rooted passion for inclusivity and accessibility. Through innovation, education, and personalized solutions, Zendolona is at the forefront of advancing the well-being and opportunities for the visually impaired and those with multiple sensory challenges, creating a world where everyone can thrive.",
+    "url": "https://zendalona.com/",
+    "category": "End user applications, Artificial Intelligence",
+    "topics": [
+      "web",
+      "accessibility",
+      "braille",
+      "gaming",
+      "AGI"
+    ],
+    "technologies": [
+      "python",
+      "javascript",
+      "android",
+      "gtk",
+      "qt"
+    ],
+    "contact_email": "zendalona@gmail.com",
+    "projects_url": "https://docs.google.com/document/d/1enwqzEqKgb9uMp2mfDDdrVaEV05yS2eHYgi6kJZXEcU/edit?tab=t.0"
+  },
+  {
+    "name": "Zulip",
+    "image_url": "https://summerofcode.withgoogle.com/media/org/zulip/sx5ruvwv6nyugbk7-360.png",
+    "image_background_color": null,
+    "description": "Zulip is the only modern team chat app that is ideal for both live and asynchronous conversations. Zulip has a web app, a cross-platform mobile app for iOS and Android, cross-platform desktop and terminal apps, and over 100 native integrations. The entire Zulip codebase is 100% open source.\n\nZulip has been gaining in popularity since it was released as open source software in late 2015, with code contributions from over 1000 people from all around the world. Thousands of people use Zulip every day, and your work on Zulip will have meaningful impact on their experience.\n\nAs an organization, we value engaged, responsive mentorship and making sure our product quality is extremely high. You can expect to receive disciplined code reviews by highly experienced engineers. Since Zulip is a team chat product, your GSoC experience with the Zulip project will be highly interactive.\n\nAs part of our commitment to mentorship, Zulip has over 160,000 words of documentation for developers, much of it designed to explain not just how Zulip works, but why Zulip works the way that it does.\n\nTo learn more about the experience of doing GSoC with Zulip, check out our blog post: https://blog.zulip.com/2025/12/02/google-summer-of-code-2025/",
+    "url": "https://zulip.com/",
+    "category": "End user applications, Social and communication",
+    "topics": [
+      "great developer tooling",
+      "visual design",
+      "teaching quality codebase",
+      "team chat",
+      "integrations"
+    ],
+    "technologies": [
+      "python",
+      "django",
+      "flutter",
+      "css",
+      "typescript"
+    ],
+    "contact_email": "",
+    "projects_url": "https://zulip.readthedocs.io/en/latest/outreach/gsoc.html"
+  }
+]


### PR DESCRIPTION
## Description

Added GSoC 2025 datasets to maintain yearly consistency with existing archives.

### Added
- `assets/projects/gsoc_org/gsoc2025org.json`
- `assets/projects/gsoc_projects/gsoc25projects.json`

### Data Source
Fetched from official GSoC 2025 API:
https://summerofcode.withgoogle.com/api/archive/programs/2025/organizations/

### Changes
- Normalized schema to match previous dataset structure
- Added technologies/topics mappings
- Maintained naming convention consistency

Fixes missing 2025 archive data support.

