### PR TITLE
Fix: Project widget tech stack background in dark mode

### DIFF
--- a/lib/widgets/gssoc_project_widget.dart
+++ b/lib/widgets/gssoc_project_widget.dart
@@ -64,7 +64,7 @@ class GssocProjectWidget extends StatelessWidget {
                     (index) => Container(
                       margin: const EdgeInsets.only(right: 10),
                       decoration: BoxDecoration(
-                        color: const Color.fromARGB(255, 249, 241, 226),
+                        color: isDarkMode ? Colors.grey.shade800 : const Color.fromARGB(255, 249, 241, 226),
                         borderRadius: BorderRadius.circular(20),
                       ),
                       child: IntrinsicWidth(


### PR DESCRIPTION
## Bug Fixed
Project showcase tech stack tags had hardcoded light background which looked odd in dark mode.

## Changes
- Changed hardcoded  to theme-aware color
- Now uses 

## Testing
- [ ] Test in light mode
- [ ] Test in dark mode

Screenshots will be added.