### PR TITLE
Refactor: update homepage by removing expired events

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -11,13 +11,13 @@ import 'package:opso/programs%20screen/djangonautspace.dart';
 import 'package:opso/programs%20screen/fossasia.dart';
 import 'package:opso/programs%20screen/girl_script.dart';
 import 'package:opso/programs%20screen/github_campus.dart';
-import 'package:opso/programs%20screen/google_season_of_docs_screen.dart';
+// import 'package:opso/programs%20screen/google_season_of_docs_screen.dart';
 import 'package:opso/programs%20screen/google_summer_of_code_screen.dart';
 import 'package:opso/programs%20screen/hacktoberfest_screen.dart';
 import 'package:opso/programs%20screen/hyperledger.dart';
 import 'package:opso/programs%20screen/linux_foundation.dart';
 import 'package:opso/programs%20screen/major_league_hacking_fellowship.dart';
-import 'package:opso/programs%20screen/open_summer_of_code.dart';
+// import 'package:opso/programs%20screen/open_summer_of_code.dart';
 import 'package:opso/programs%20screen/outreachy.dart';
 import 'package:opso/programs%20screen/redox.dart';
 import 'package:opso/programs%20screen/season_of_kde.dart';
@@ -92,10 +92,10 @@ class _HomePageState extends State<HomePage> {
       title: 'Google Summer of Code',
       imageAssetPath: 'assets/gsoc_logo.png',
     ),
-    Program(
+    /*Program( PROGRAM CONCLUDED
       title: 'Google Season of Docs',
       imageAssetPath: 'assets/Google_season_of_docs.png',
-    ),
+    ),*/
     Program(
       title: 'FOSSASIA Codeheat',
       imageAssetPath: 'assets/fossasia.png',
@@ -148,10 +148,10 @@ class _HomePageState extends State<HomePage> {
       title: 'Redox OS Summer of Code',
       imageAssetPath: 'assets/redox.png',
     ),
-    Program(
+    /*Program( NOT DONE IN 2025 NO INFORMATION ABOUT 2026
       title: 'Open Summer of Code',
       imageAssetPath: 'assets/open_summer_of_code.png',
-    ),
+    ),*/
   ];
 
 
@@ -159,8 +159,8 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     // var media = MediaQuery.of(context).size;
     Color backgroundColor = Theme.of(context).brightness == Brightness.dark
-        ? Colors.black.withOpacity(0.6) // Example dark mode color
-        : Colors.white.withOpacity(0.6); // Example light mode color
+        ? Colors.black.withValues(alpha: 0.6) // Example dark mode color
+        : Colors.white.withValues(alpha: 0.6); // Example light mode color
 
 
     ScreenUtil.init(
@@ -395,14 +395,14 @@ class _HomePageState extends State<HomePage> {
         break;
 
 
-      case 'Google Season of Docs':
-        Navigator.push(
+      /*case 'Google Season of Docs':
+        Navigator.push( PROGRAM CONCLUDED
           context,
           MaterialPageRoute(
             builder: (context) => GoogleSeasonOfDocsScreen(),
           ),
         );
-        break;
+        break;*/
 
       case 'FOSSASIA Codeheat':
         Navigator.push(
@@ -490,7 +490,7 @@ class _HomePageState extends State<HomePage> {
             MaterialPageRoute(builder: (context) => const OutreachyScreen(),
             ),
             );
-
+        break;
 
       
 
@@ -499,22 +499,24 @@ class _HomePageState extends State<HomePage> {
             MaterialPageRoute(builder: (context) => const Hacktoberfest(),
             ),
             );
+            break;
       
       case 'Github Campus Expert':
         Navigator.push(context,
             MaterialPageRoute(builder: (context) => const GithubCampus(),
             ),
             );
+            break;
       
 
-      case 'Open Summer of Code':
-
+      /*case 'Open Summer of Code':
+        NOT DONE IN 2025 NO INFORMATION ABOUT 2026      
         Navigator.push(
           context,
           MaterialPageRoute(
             builder: (context) => const OpenSummerOfCode(),
           ),
-        );
+        );*/
 
 
       case 'Linux Foundation':
@@ -522,6 +524,7 @@ class _HomePageState extends State<HomePage> {
             MaterialPageRoute(builder: (context) => const LinuxFoundation(),
             ),
             );
+            break;
 
 
 
@@ -599,10 +602,10 @@ class ProgramSearchDelegate extends SearchDelegate<String> {
       title: 'Google Summer of Code',
       imageAssetPath: 'assets/gsoc_logo.png',
     ),
-    Program(
+    /*Program( PROGRAM CONCLUDED
       title: 'Google Season of Docs',
       imageAssetPath: 'assets/Google_season_of_docs.png',
-    ),
+    ),*/
     Program(
       title: 'FOSSASIA Codeheat',
       imageAssetPath: 'assets/fossasia.png',
@@ -656,10 +659,10 @@ class ProgramSearchDelegate extends SearchDelegate<String> {
       title: 'Season of KDE',
       imageAssetPath: 'assets/sokde.png',
     ),
-    Program(
+    /*Program(NOT DONE IN 2025 NO INFORMATION ABOUT 2026
       title: 'Open Summer of Code',
       imageAssetPath: 'assets/open_summer_of_code.png',
-    ),
+    ),*/
   ];
 
 
@@ -729,14 +732,14 @@ class ProgramSearchDelegate extends SearchDelegate<String> {
         );
         break;
 
-      case 'Google Season of Docs':
-        Navigator.push(
+      /*case 'Google Season of Docs':
+        Navigator.push( PROGRAM CONCLUDED
           context,
           MaterialPageRoute(
             builder: (context) => GoogleSeasonOfDocsScreen(),
           ),
         );
-        break;
+        break;*/
 
       case 'FOSSASIA Codeheat':
         Navigator.push(
@@ -791,10 +794,6 @@ class ProgramSearchDelegate extends SearchDelegate<String> {
           ),
         );
         break;
-
-      
-
-     
 
       case 'Outreachy':
         Navigator.push(
@@ -862,16 +861,14 @@ class ProgramSearchDelegate extends SearchDelegate<String> {
             );
         break;
 
-        case 'Open Summer of Code':
-        Navigator.push(
+        /*case 'Open Summer of Code':
+        Navigator.push( NOT DONE IN 2025 NO INFORMATION ABOUT 2026
           context,
           MaterialPageRoute(
             builder: (context) => const OpenSummerOfCode(),
           ),
         );
-        break;
-
-
+        break;*/
 
       default:
         break;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,12 +55,11 @@ class OpSoApp extends StatelessWidget {
                 "/season_of_kde": (context) => const SeasonOfKDE(),
                 "/google_summer_of_code": (context) =>
                     const GoogleSummerOfCodeScreen(),
-                "/google_season_of_docs": (context) =>
-                    GoogleSeasonOfDocsScreen(),
+                // "/google_season_of_docs": (context) => GoogleSeasonOfDocsScreen(), PROGRAM CONCLUDED 
                 "/summer_of_bitcoin": (context) => const SummerOfBitcoin(),
                 "/fossasia": (context) => const FOSSASIA(),
                 "/Hacktoberfest": (context) => const Hacktoberfest(),
-                "/open_summer_of_code": (context) => const OpenSummerOfCode(),
+                // "/open_summer_of_code": (context) => const OpenSummerOfCode(), NOT DONE IN 2025 NO INFORMATION ABOUT 2026
                 "/hyperledger": (context) => const Hyperledger(),
                 "/rsoc": (context) => const RsocPage(),
                 "/outreachy": (context) => const OutreachyScreen(),


### PR DESCRIPTION
## Problem / Issue No.
- Closes : #430 
- The homepage was displaying outdated/expired events, which reduced content relevance and affected the overall user experience.



## Describe Problem / Root Cause
- Event data previously added to the homepage was not updated or removed after the events expired, causing old information to remain visible to users.



## Solution proposed
- Removed expired and outdated events from the homepage.
- Cleaned up the homepage section to improve content accuracy and maintain a more updated UI experience.



## Additional Information
- No functional logic was changed outside of homepage content cleanup.

## Note
- Kindly add the `gssoc : approved` and appropriate `level` labels to this PR during review/merge for proper identification.

