### PR TITLE
fix: correct routing and error message typos

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ class OpSoApp extends StatelessWidget {
             builder: (theme, darkTheme) => MaterialApp(
               initialRoute: '/splash_screen',
               routes: {
-                "/progarm_page": (context) => const HomePage(),
+                "/program_page": (context) => const HomePage(),
                 "/girl_script_summer_of_code": (context) => const GSSOCScreen(),
                 "/social_winter_of_code": (context) => const SWOCScreen(),
                 "/season_of_kde": (context) => const SeasonOfKDE(),

--- a/lib/programs screen/open_summer_of_code.dart
+++ b/lib/programs screen/open_summer_of_code.dart
@@ -278,7 +278,7 @@ class _OpenSummerOfCodeState extends State<OpenSummerOfCode> {
                   ),
                 );
               } else {
-                return const Center(child: Text("Some error occured"));
+                return const Center(child: Text("Some error occurred"));
               }
             }),
       ),

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -11,7 +11,7 @@ class _SplashScreenState extends State<SplashScreen> {
   void initState() {
     super.initState();
     Timer(Duration(seconds: 3), () {
-      Navigator.of(context).pushReplacementNamed('/progarm_page');
+      Navigator.of(context).pushReplacementNamed('/program_page');
     });
   }
 


### PR DESCRIPTION
## Problem / Issue No.
- Typos found in the code causing incorrect route name and a misspelled error message.
- Issue reference: #443

## Describe Problem / Root Cause
- The route name was misspelled as `/progarm_page` in `lib/main.dart` and `lib/splash_screen.dart`.
- An error message was misspelled as "Some error occured" in `lib/programs screen/open_summer_of_code.dart`.
- Root cause: simple spelling mistakes in string literals.

## Solution proposed
- Corrected route name to `/program_page` in `lib/main.dart` and `lib/splash_screen.dart`.
- Corrected error message to "Some error occurred" in `lib/programs screen/open_summer_of_code.dart`.
- No logic or behavior changes — only string fixes.

## Additional Information
- Small fix, so nothing risky here.
- The changes are already pushed in the `typo-fix` branch.
- Should be quick to check and merge.

## Screenshots
- Not required for this change.

Fixes #443