### PR TITLE
fix: handle project showcase images in dark mode

### DIFF
--- a/lib/widgets/gsoc/GsocProjectWidget.dart
+++ b/lib/widgets/gsoc/GsocProjectWidget.dart
@@ -118,12 +118,18 @@ class GsocProjectWidget extends StatelessWidget {
                                     children: [
                                       Container(
                                         padding: EdgeInsets.all(20),
-                                        color: Colors.grey[100],
+                                        color: isDarkMode ? Colors.grey[800]: Colors.grey[100],
                                         child: Center(
-                                          child: Image.network(
-                                            modal.imageUrl,
-                                            width: 80,
-                                            height: 80,
+                                          child: ColorFiltered(
+                                            colorFilter: ColorFilter.mode(
+                                              isDarkMode ? Colors.white.withOpacity(0.85) : Colors.transparent,
+                                              BlendMode.dstOver,
+                                            ),
+                                            child: Image.network(
+                                              modal.imageUrl,
+                                              width: 80,
+                                              height: 80,
+                                            ),
                                           ),
                                         ),
                                       ),


### PR DESCRIPTION
## Description

Fixes project showcase images that have white backgrounds looking out of place in dark mode.

### Changes:
- Updated GsocProjectWidget to use ColorFiltered with BlendMode.dstOver in dark mode
- Image container background now adapts to dark/light theme
- White-background images blend naturally with the dark theme

Closes #435