### PR TITLE
fix: make GsocProjectWidget and bottom sheet dark-mode friendly

### DIFF
--- a/lib/widgets/gsoc/GsocProjectWidget.dart
+++ b/lib/widgets/gsoc/GsocProjectWidget.dart
@@ -102,7 +102,7 @@ class GsocProjectWidget extends StatelessWidget {
                   child: ElevatedButton(
                       onPressed: () {
                         showModalBottomSheet(
-                          backgroundColor: Colors.white,
+                          backgroundColor: isDarkMode ? Colors.grey.shade900 : Colors.white,
                           showDragHandle: true,
                           context: context,
                           isScrollControlled: true,
@@ -117,14 +117,30 @@ class GsocProjectWidget extends StatelessWidget {
                                         CrossAxisAlignment.start,
                                     children: [
                                       Container(
-                                        padding: EdgeInsets.all(20),
-                                        color: Colors.grey[100],
+                                        padding: const EdgeInsets.all(20),
+                                        decoration: BoxDecoration(
+                                          color: isDarkMode
+                                              ? Colors.grey.shade800
+                                              : Colors.grey[100],
+                                          borderRadius: BorderRadius.circular(12),
+                                        ),
                                         child: Center(
-                                          child: Image.network(
-                                            modal.imageUrl,
-                                            width: 80,
-                                            height: 80,
-                                          ),
+                                          child: isDarkMode
+                                              ? ColorFiltered(
+                                                  colorFilter: ColorFilter.mode(
+                                                      Colors.grey.shade800,
+                                                      BlendMode.multiply),
+                                                  child: Image.network(
+                                                    modal.imageUrl,
+                                                    width: 80,
+                                                    height: 80,
+                                                  ),
+                                                )
+                                              : Image.network(
+                                                  modal.imageUrl,
+                                                  width: 80,
+                                                  height: 80,
+                                                ),
                                         ),
                                       ),
                                       SizedBox(
@@ -141,6 +157,7 @@ class GsocProjectWidget extends StatelessWidget {
                                         itemCount: modal.projects.length,
                                         itemBuilder: (context, projectIndex) {
                                           return _buildProjectCard(
+                                              context,
                                               modal.projects[projectIndex]);
                                         },
                                       )
@@ -163,9 +180,14 @@ class GsocProjectWidget extends StatelessWidget {
     );
   }
 
-  Widget _buildProjectCard(Project project) {
+  Widget _buildProjectCard(BuildContext context, Project project) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final cardColor = isDarkMode ? Colors.grey.shade800 : Colors.grey[100];
+    final textColor = isDarkMode ? Colors.white70 : Colors.grey[700];
+    final titleColor = isDarkMode ? Colors.white : Colors.black;
+
     return Card(
-      color: Colors.grey[100],
+      color: cardColor,
       elevation: 0,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       child: Padding(
@@ -175,13 +197,16 @@ class GsocProjectWidget extends StatelessWidget {
           children: [
             Text(
               project.title,
-              style: TextStyle(fontWeight: FontWeight.w600),
+              style: TextStyle(
+                fontWeight: FontWeight.w600,
+                color: titleColor,
+              ),
             ),
             SizedBox(
               height: 10,
             ),
             Text(project.shortDescription,
-                style: TextStyle(color: Colors.grey[700])),
+                style: TextStyle(color: textColor)),
             SizedBox(
               height: 10,
             ),


### PR DESCRIPTION
## Problem / Issue No.
- Closes #436
- Resolves #435

## Describe Problem / Root Cause
- In dark mode, GSoC project organization showcase images with white backgrounds stood out harshly, and the parent container had a hardcoded `color: Colors.grey[100]` background, which rendered as a bright box in dark mode.
- In addition, the bottom sheet background (`Colors.white`) and project detail cards (`color: Colors.grey[100]`) were not dark-theme compatible.

## Solution proposed
- Modified `GsocProjectWidget.dart` to make the image container's background adaptive (`isDarkMode ? Colors.grey.shade800 : Colors.grey[100]`).
- Wrapped `Image.network` in a `ColorFiltered` with `BlendMode.multiply` in dark mode to blend white-background images with the dark container.
- Updated the bottom sheet background to be dark-theme compatible (`backgroundColor: isDarkMode ? Colors.grey.shade900 : Colors.white`).
- Made the project detail cards and text inside the bottom sheet adaptive to dark/light mode.

## Additional Information
- Tested on responsive viewports; layout is fully preserved.

## Screenshots
- Updated: Clean dark container with blended organization images.
