### PR TITLE
fix: remove debug print statement from ApiService

### DIFF
--- a/lib/services/ApiService.dart
+++ b/lib/services/ApiService.dart
@@ -30,7 +30,6 @@ class ApiService {
         break;
     }
     final String allOrg = '$baseUrl$yearOrgUrl';
-    print("status is" + allOrg);
     try {
       Response response = await Dio().get(allOrg + ".json");
       if (response.statusCode == 200) {


### PR DESCRIPTION
## Description

Removes a debug `print()` statement from production code in `ApiService`.

## Problem

In `lib/services/ApiService.dart`, line 33 contained:
```dart
print("status is" + allOrg);
```
This leaks the internal API URL to the console in production builds, which:
- Degrades performance
- Can expose internal implementation details
- Violates linting standards (avoid_print lint rule)

## Fix

Removed the `print()` statement entirely.

## Related Issue
Fixes #417 (Improved linting and code quality)

## Type of Change
- [x] Bug fix (removing debug code from production)

## Checklist
- [x] Tests pass
- [x] No lint warnings introduced
- [x] Code follows project style guidelines