### PR TITLE
fix: remove debug print statements from BookMarkScreen

### DIFF
--- a/lib/widgets/book_mark_screen.dart
+++ b/lib/widgets/book_mark_screen.dart
@@ -35,14 +35,11 @@ class _BookMarkScreenState extends State<BookMarkScreen> {
       body: FutureBuilder<List<Map<String, String>>>(
         future: bookmarks,
         builder: (context, snapshot) {
-          print("working");
-          print(snapshot.data);
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           } else if (snapshot.hasError) {
             return const Center(child: Text('Error loading bookmarks'));
           } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-            print(bookmarks);
             return const Center(child: Text('No bookmarks available'));
           } else {
             final bookmarks = snapshot.data!;


### PR DESCRIPTION
## Description

Removes 3 debug `print()` statements from the `BookMarkScreen` widget's FutureBuilder.

## Problem

In `lib/widgets/book_mark_screen.dart`, the FutureBuilder's builder callback contained:
```dart
print("working");
print(snapshot.data);
// ... 
print(bookmarks);
```

These run on **every widget rebuild**, causing:
- Performance degradation (print() on rebuild is costly)
- Sensitive bookmark data logged to console
- Violation of the `avoid_print` lint rule from #417

## Fix

Removed all 3 `print()` statements. The logic is unchanged.

## Related Issue
Fixes #417 (Improved linting and code quality)

## Type of Change
- [x] Bug fix (removing debug code from production)

## Checklist
- [x] No functional changes — only debug code removed
- [x] Tests pass
- [x] No lint warnings introduced