### PR TITLE
fix: remove debug print statements from SeasonOfKDE and Hyperledger screens

### DIFF
--- a/lib/programs screen/hyperledger.dart
+++ b/lib/programs screen/hyperledger.dart
@@ -36,7 +36,6 @@ class _HyperledgerState extends State<Hyperledger> {
       hyperledger2024.add(HyperledgerProjectModal.fromJson(data));
     }
     projectList = hyperledger2024;
-    print(projectList);
     response = await rootBundle
         .loadString('assets/projects/hyperledger/hyperledger2023.json');
     jsonList = await json.decode(response);

--- a/lib/programs screen/season_of_kde.dart
+++ b/lib/programs screen/season_of_kde.dart
@@ -35,7 +35,6 @@ class _SeasonOfKDEState extends State<SeasonOfKDE> {
       sokde2024.add(SokdeProjectModal.fromJson(data));
     }
     projectList = sokde2024;
-    print(projectList);
     response =
         await rootBundle.loadString('assets/projects/sokde/sokde2023.json');
     jsonList = await json.decode(response);


### PR DESCRIPTION
## Description

Removes debug `print()` statements from two program screens that run during app initialization.

## Problem

Both `SeasonOfKDE` and `Hyperledger` screens contained identical debug logging in their `initializeProjectLists()` method:
```dart
projectList = <year>Data;
print(projectList); // <-- dumps entire project list to console
```

This runs on **every app start and every pull-to-refresh**, dumping potentially hundreds of project objects to the console, which:
- Degrades startup performance
- Violates the `avoid_print` lint rule from #417

## Files Changed
- `lib/programs screen/season_of_kde.dart` — removed `print(projectList)` on line 38
- `lib/programs screen/hyperledger.dart` — removed `print(projectList)` on line 39

## Related Issue
Fixes #417 (Improved linting and code quality)

## Type of Change
- [x] Bug fix (removing debug code from production)

## Checklist
- [x] No functional changes — only debug logs removed
- [x] No lint warnings introduced
- [x] Code follows project style guidelines