### PR TITLE
fix: replace print() with debugPrint() in SWOCScreen and LinuxFoundation

### DIFF
--- a/lib/programs screen/linux_foundation.dart
+++ b/lib/programs screen/linux_foundation.dart
@@ -100,10 +100,8 @@ class _LinuxFoundationState extends State<LinuxFoundation> {
                 ),
               );
               if (isBookmarked) {
-                print("Adding");
                 HandleBookmark.addBookmark(currentProject, currectPage);
               } else {
-                print("Deleting");
                 HandleBookmark.deleteBookmark(currentProject);
               }
             },
@@ -165,7 +163,6 @@ class _LinuxFoundationState extends State<LinuxFoundation> {
                             horizontal: ScreenUtil().setWidth(40)),
                       ),
                       onFieldSubmitted: (value) {
-                        print("value is $value");
                         search(value.trim());
                       },
                       onChanged: (value) {

--- a/lib/programs screen/social_winter_of_code.dart
+++ b/lib/programs screen/social_winter_of_code.dart
@@ -71,12 +71,11 @@ class _SWOCScreenState extends State<SWOCScreen> {
         list.addAll(jsonList
             .map((data) => SwocProjectModal.getDataFromJson(data))
             .toList());
-        print('Loaded projects from $path: ${list.length}');
       } else {
-        print('Error: JSON data is null or empty in $path');
+        debugPrint('Warning: JSON data is null or empty in $path');
       }
     } catch (e) {
-      print('Error loading projects from $path: $e');
+      debugPrint('Error loading projects from $path: $e');
     }
   }
 


### PR DESCRIPTION
## Description

Removes or replaces debug `print()` statements in two program screens.

## Problem

Both screens used bare `print()` statements that run in production:

**`social_winter_of_code.dart`** — `_loadProjects()` method:
```dart
print('Loaded projects from $path: ${list.length}');  // runs for every JSON file loaded
print('Error: JSON data is null or empty in $path');
print('Error loading projects from $path: $e');
```

**`linux_foundation.dart`** — bookmark toggle & search callbacks:
```dart
print("Adding");     // runs on every bookmark add
print("Deleting");   // runs on every bookmark remove
print("value is $value");  // runs on every search submit
```

## Fix

- **SWoC**: Removed the success log (not needed), replaced error logs with `debugPrint()` (stripped in release builds automatically by Flutter)
- **Linux Foundation**: Removed all 3 statements entirely (no diagnostic value)

## Related Issue
Fixes #417 (Improved linting and code quality)

## Type of Change
- [x] Bug fix (removing/replacing debug code from production)

## Checklist
- [x] No functional changes
- [x] `debugPrint()` is Flutter's recommended replacement for `print()` in widget code
- [x] Tests pass
- [x] No lint warnings introduced