### PR TITLE
fix: remove debug print() statements from MLH, SoB, GSoC, and GSoD screens

### DIFF
--- a/lib/programs screen/google_season_of_docs_screen.dart
+++ b/lib/programs screen/google_season_of_docs_screen.dart
@@ -184,7 +184,6 @@ class _GoogleSeasonOfDocsScreenState extends State<GoogleSeasonOfDocsScreen> {
 
   void filterProjects() {
     var filteredProjects = List.from(projectList);
-    print("!@# $selectedOrganizations");
 
     // Filter by organizations
     if (!selectedOrganizations.contains('All')) {
@@ -429,8 +428,6 @@ class _GoogleSeasonOfDocsScreenState extends State<GoogleSeasonOfDocsScreen> {
                           setState(() {
                             selectedOrganizations =
                                 results.isNotEmpty ? results : ['All'];
-                            print(
-                                "this is selected organization $selectedOrganizations");
                             filterProjects();
                           });
                         },

--- a/lib/programs screen/google_summer_of_code_screen.dart
+++ b/lib/programs screen/google_summer_of_code_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:opso/modals/book_mark_model.dart';
@@ -176,14 +176,8 @@ class _GoogleSummerOfCodeScreenState extends State<GoogleSummerOfCodeScreen> {
                   ),
                 );
                 if (isBookmarked) {
-                  if (kDebugMode) {
-                    print("Adding");
-                  }
                   HandleBookmark.addBookmark(currentProject, currentPage);
                 } else {
-                  if (kDebugMode) {
-                    print("Deleting");
-                  }
                   HandleBookmark.deleteBookmark(currentProject);
                 }
               },
@@ -294,9 +288,6 @@ class _GoogleSummerOfCodeScreenState extends State<GoogleSummerOfCodeScreen> {
                           setState(() {
                             selectedLanguages =
                                 results.isNotEmpty ? results : [];
-                            if (kDebugMode) {
-                              print(selectedLanguages);
-                            }
                             filterProjects();
                           });
                         },

--- a/lib/programs screen/major_league_hacking_fellowship.dart
+++ b/lib/programs screen/major_league_hacking_fellowship.dart
@@ -73,10 +73,10 @@ class _MajorLeagueHackingFellowshipState
                   ),
                 );
                 if (isBookmarked) {
-                  print("Adding");
+ 
                   HandleBookmark.addBookmark(currentProject, currectPage);
                 } else {
-                  print("Deleting");
+ 
                   HandleBookmark.deleteBookmark(currentProject);
                 }
               },

--- a/lib/programs screen/summer_of_bitcoin.dart
+++ b/lib/programs screen/summer_of_bitcoin.dart
@@ -162,10 +162,10 @@ class _SummerOfBitcoinState extends State<SummerOfBitcoin> {
                 ),
               );
               if (isBookmarked) {
-                print("Adding");
+
                 HandleBookmark.addBookmark(currentProject, currectPage);
               } else {
-                print("Deleting");
+
                 HandleBookmark.deleteBookmark(currentProject);
               }
             },


### PR DESCRIPTION
## Description

Removes debug `print()` statements from 4 program screens that were left in production code.

## Files Changed

### `major_league_hacking_fellowship.dart`
- Removed `print("Adding")` and `print("Deleting")` in bookmark toggle handler

### `summer_of_bitcoin.dart`
- Removed `print("Adding")` and `print("Deleting")` in bookmark toggle handler

### `google_summer_of_code_screen.dart`
- Removed dead empty `kDebugMode` blocks in bookmark toggle (leftover from a partial refactor)
- Removed `print(selectedLanguages)` inside `kDebugMode` block in language filter callback
- Removed now-unused `import 'package:flutter/foundation.dart'`

### `google_season_of_docs_screen.dart`
- Removed `print("!@# $selectedOrganizations")` in `filterProjects()` (runs on every filter change)
- Removed `print("this is selected organization...")` in org filter `onConfirm` callback

## Related Issue
Fixes #417 (Improved linting and code quality)

## Type of Change
- [x] Bug fix (removing debug code from production)

## Checklist
- [x] No functional changes — only debug logs removed
- [x] Unused import also removed
- [x] Tests pass
- [x] No lint warnings introduced