### PR TITLE
docs: update issue tracker link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Thank you for considering contributing to OpSo! We welcome contributions from th
 
 ### Bug Reports and Feature Requests
 
-If you encounter any bugs or have ideas for new features, please [open an issue](https://github.com/yourusername/OpSo/issues) on GitHub. Make sure to provide detailed information about the issue or feature request, including steps to reproduce the bug if applicable.
+If you encounter any bugs or have ideas for new features, please [open an issue](https://github.com/andoriyaprashant/OpSo/issues) on GitHub. Make sure to provide detailed information about the issue or feature request, including steps to reproduce the bug if applicable.
 
 ### Code Contributions
 


### PR DESCRIPTION
## Problem / Issue No.
- The README contained a placeholder GitHub issue link (`yourusername`) instead of the actual repository issue tracker.

## Describe Problem / Root Cause
- The placeholder URL was never updated, causing contributors to be redirected to a non-existent issue page.

## Solution proposed
- Replaced the placeholder issue link with the correct GitHub Issues URL for the OpSo repository.
- This ensures contributors can directly access the project's issue tracker.

## Additional Information
- This is a documentation-only change and does not affect the application's functionality.

## Screenshots
- Original Screenshot (Problem/Issue): N/A
- Updated Screenshot (Fixes/Solution): N/A

### Related Issue
Closes #None (just a documentation quick fix)